### PR TITLE
Implement Document.validate()

### DIFF
--- a/sbol2/config.py
+++ b/sbol2/config.py
@@ -41,7 +41,7 @@ options = {
     ConfigOptions.SBOL_TYPED_URIS.value: True,
     ConfigOptions.SERIALIZATION_FORMAT.value: 'sbol',
     ConfigOptions.VALIDATE.value: True,
-    ConfigOptions.VALIDATOR_URL.value: 'http://www.async.ece.utah.edu/validate/',
+    ConfigOptions.VALIDATOR_URL.value: 'https://validator.sbolstandard.org/validate/',
     ConfigOptions.LANGUAGE.value: 'SBOL2',
     ConfigOptions.TEST_EQUALITY.value: False,
     ConfigOptions.CHECK_URI_COMPLIANCE.value: False,

--- a/sbol2/config.py
+++ b/sbol2/config.py
@@ -178,23 +178,22 @@ class Config:
         :param val: The option value (str or bool expected)
         :return: None
         """
-        if option in options:
-            if option in valid_options:
-                if val in valid_options[option]:
-                    options[option] = val
-                else:
-                    raise SBOLError(SBOLErrorCode.SBOL_ERROR_INVALID_ARGUMENT,
-                                    val +
-                                    ' is not a valid value for '
-                                    'this option. Valid options are ' +
-                                    str(valid_options[option]))
-            else:
-                # Any argument is valid, eg. uriPrefix
+        # Convert a config option to its string value
+        if isinstance(option, ConfigOptions):
+            option = option.value
+        if option not in options:
+            msg = '{!r} is not a valid configuration option'.format(option)
+            raise SBOLError(msg, SBOLErrorCode.SBOL_ERROR_INVALID_ARGUMENT)
+        if option in valid_options:
+            if val in valid_options[option]:
                 options[option] = val
+            else:
+                msg = '{!r} is not a valid value for option {!r}.'.format(val, option)
+                msg += ' Valid options are: {!r}.'.format(valid_options[option])
+                raise SBOLError(msg, SBOLErrorCode.SBOL_ERROR_INVALID_ARGUMENT)
         else:
-            raise SBOLError(SBOLErrorCode.SBOL_ERROR_INVALID_ARGUMENT,
-                            option +
-                            ' is not a valid configuration option for libSBOL')
+            # Any argument is valid, eg. uriPrefix
+            options[option] = val
 
     @staticmethod
     def getOption(option):
@@ -203,12 +202,14 @@ class Config:
         :param option: The option key
         :return: The option value
         """
+        # Convert a config option to its string value
+        if isinstance(option, ConfigOptions):
+            option = option.value
         if option in options:
             return options[option]
         else:
-            raise SBOLError(SBOLErrorCode.SBOL_ERROR_INVALID_ARGUMENT,
-                            str(option) +
-                            ' not a valid configuration option for libSBOL')
+            msg = '{!r} is not a valid configuration option'.format(option)
+            raise SBOLError(msg, SBOLErrorCode.SBOL_ERROR_INVALID_ARGUMENT)
 
 
 # Global methods


### PR DESCRIPTION
* Implement Document.validate() using request_validation() as a supporting function as is done in pySBOL and to support better unit testing
* Update the validator URL
* Use Document.writeString() to generate the text that will be validated
* Enhance Config.setOption and Config.getOption to accept ConfigOption in addition to string for the option name
* Fix up SBOLErrors in Config to pass arguments in the correct order

Fixes #155 