### PR TITLE
Allow assignment of OwnedObject attributes

### DIFF
--- a/sbol2/object.py
+++ b/sbol2/object.py
@@ -446,10 +446,14 @@ class SBOLObject:
     def _set_referenced_object(self, name, value):
         self.__dict__[name].set(value)
 
+    def _set_owned_object(self, name, value):
+        self.__dict__[name].set(value)
+
     def __setattr__(self, name, value):
         if self._is_referenced_object(name):
             self._set_referenced_object(name, value)
             return
         if self._is_owned_object(name):
-            raise AttributeError('Cannot set owned object. Use set or add methods.')
+            self._set_owned_object(name, value)
+            return
         object.__setattr__(self, name, value)

--- a/sbol2/test/test_ownedobject.py
+++ b/sbol2/test/test_ownedobject.py
@@ -89,8 +89,8 @@ class TestOwnedObject(unittest.TestCase):
         md = doc.moduleDefinitions.create('foo')
         m1 = sbol.Module('m1')
         m2 = sbol.Module('m2')
-        with self.assertRaises(AttributeError):
-            md.modules = [m1, m2]
+        md.modules = [m1, m2]
+        self.assertEqual(list(md.modules), [m1, m2])
 
     def test_set_no_doc(self):
         # Add a module when the parent module definition is not in a


### PR DESCRIPTION
Allow assignment via `=` of owned object attributes using `__setattr__`. Adjust tests accordingly.

This lies on the path to [extensions](#7) and is seen in the wild in at least one SD2 script.

Fixes #157