### PR TITLE
Make Activity.agent a ReferencedObject

### DIFF
--- a/sbol2/provo.py
+++ b/sbol2/provo.py
@@ -199,8 +199,8 @@ class Activity(TopLevel):
         super().__init__(rdf_type, uri, version)
         self.plan = OwnedObject(self, PROVO_PLAN, Plan,
                                 '0', '1', [validation.libsbol_rule_22])
-        self.agent = OwnedObject(self, PROVO_AGENT, Agent,
-                                 '0', '1', [validation.libsbol_rule_22])
+        self.agent = ReferencedObject(self, PROVO_AGENT, Agent,
+                                      '0', '1', [validation.libsbol_rule_22])
         self._types = URIProperty(self, SBOL_TYPES, '0', '1', [])
         self._startedAtTime = LiteralProperty(self, PROVO_STARTED_AT_TIME,
                                               '0', '1', [])

--- a/sbol2/test/__init__.py
+++ b/sbol2/test/__init__.py
@@ -16,6 +16,7 @@ from .test_object import TestObject
 from .test_ownedobject import TestOwnedObject
 from .test_partshop import TestPartShop
 from .test_property import TestProperty
+from .test_provo import TestProvo
 from .test_referencedobject import TestReferencedObjects
 from .test_roundtrip import TestRoundTripSBOL2, TestRoundTripFailSBOL2
 from .test_sequence import TestSequence
@@ -43,6 +44,7 @@ def runTests(test_list=None):
             TestOwnedObject,
             TestPartShop,
             TestProperty,
+            TestProvo,
             TestReferencedObjects,
             TestSbolTutorial,
             TestSequence,

--- a/sbol2/test/test_provo.py
+++ b/sbol2/test/test_provo.py
@@ -1,0 +1,14 @@
+import unittest
+
+import sbol2
+
+
+class TestProvo(unittest.TestCase):
+
+    def test_activity_agent(self):
+        # Verify that the agent attribute is a ReferencedObject
+        doc = sbol2.Document()
+        agent = doc.agents.create('007')
+        activity = doc.activities.create('spying')
+        activity.agent = agent
+        self.assertEqual(activity.agent, agent.identity)


### PR DESCRIPTION
Adhere to the SBOL spec by making agent a referenced object attribute.

Fixes #161 