### PR TITLE
Handle unordered lists in SBOLObject.__eq__

### DIFF
--- a/sbol2/object.py
+++ b/sbol2/object.py
@@ -237,6 +237,26 @@ class SBOLObject:
         # TODO This may work differently than the original method...
         return self == comparand
 
+    def compare_properties(self, other):
+        if sorted(self.properties.keys()) != sorted(other.properties.keys()):
+            return False
+        # Keys are equal, check values by converting to sets
+        for k in self.properties.keys():
+            if set(self.properties[k]) != set(other.properties[k]):
+                return False
+        return True
+
+    def compare_owned_objects(self, other):
+        if sorted(self.owned_objects.keys()) != sorted(other.owned_objects.keys()):
+            return False
+        # Keys are equal, check values by converting to dicts
+        for k in self.owned_objects.keys():
+            oo1 = {oo.identity: oo for oo in self.owned_objects[k]}
+            oo2 = {oo.identity: oo for oo in other.owned_objects[k]}
+            if oo1 != oo2:
+                return False
+        return True
+
     def __eq__(self, other):
         """Compare two SBOLObjects. The behavior is currently undefined for
         objects with custom annotations or extension classes.
@@ -249,9 +269,9 @@ class SBOLObject:
             return False
         if self.rdf_type != other.rdf_type:
             return False
-        if self.properties != other.properties:
+        if not self.compare_properties(other):
             return False
-        if self.owned_objects != other.owned_objects:
+        if not self.compare_owned_objects(other):
             return False
         return True
 

--- a/sbol2/test/test_object.py
+++ b/sbol2/test/test_object.py
@@ -174,7 +174,7 @@ class TestObject(unittest.TestCase):
         # Verify that a warning was issued
         self.assertEqual(len(warns), 1)
 
-    def test_eq_unordered_properties(self):
+    def test_compare_properties(self):
         # Test that two objects are equal even if a property is in a
         # different order
         expected1 = [sbol2.SBO_INHIBITION, sbol2.SBO_CONTROL]
@@ -185,7 +185,7 @@ class TestObject(unittest.TestCase):
         md2.roles = expected2
         self.assertTrue(md1.compare(md2))
 
-    def test_eq_unordered_owned_objects(self):
+    def test_compare_owned_objects(self):
         # Test that two objects are equal even if owned objects are in
         # a different order
         expected1 = [sbol2.Module('m1'), sbol2.Module('m2')]
@@ -195,3 +195,27 @@ class TestObject(unittest.TestCase):
         md2 = sbol2.ModuleDefinition('md1')
         md2.modules = expected2
         self.assertTrue(md1.compare(md2))
+
+    def test_compare_recursive(self):
+        # Test that the compare method is doing a recursive compare
+        m1a = sbol2.Module('m1')
+        m1b = sbol2.Module('m1')
+        # m1a and m1b compare True
+        self.assertTrue(m1a.compare(m1b))
+        m2 = sbol2.Module('m2')
+        # m2 is different from m1a and m1b
+        self.assertFalse(m2.compare(m1a))
+        self.assertFalse(m2.compare(m1b))
+
+        md1a = sbol2.ModuleDefinition('md1')
+        md1b = sbol2.ModuleDefinition('md1')
+        # md1a and md1b compare True
+        self.assertTrue(md1a.compare(md1b))
+        md1a.modules = [m1a]
+        md1b.modules = [m1b]
+        # md1a and md1b still compare True
+        self.assertTrue(md1a.compare(md1b))
+        md1a.modules = [m2]
+        # Now md1a and md1b compare False because of recursive
+        # comparison of modules
+        self.assertFalse(md1a.compare(md1b))

--- a/sbol2/test/test_object.py
+++ b/sbol2/test/test_object.py
@@ -173,3 +173,25 @@ class TestObject(unittest.TestCase):
             self.assertEqual(md.this, md)
         # Verify that a warning was issued
         self.assertEqual(len(warns), 1)
+
+    def test_eq_unordered_properties(self):
+        # Test that two objects are equal even if a property is in a
+        # different order
+        expected1 = [sbol2.SBO_INHIBITION, sbol2.SBO_CONTROL]
+        expected2 = [sbol2.SBO_CONTROL, sbol2.SBO_INHIBITION]
+        md1 = sbol2.ModuleDefinition('md1')
+        md1.roles = expected1
+        md2 = sbol2.ModuleDefinition('md1')
+        md2.roles = expected2
+        self.assertTrue(md1.compare(md2))
+
+    def test_eq_unordered_owned_objects(self):
+        # Test that two objects are equal even if owned objects are in
+        # a different order
+        expected1 = [sbol2.Module('m1'), sbol2.Module('m2')]
+        expected2 = [sbol2.Module('m2'), sbol2.Module('m1')]
+        md1 = sbol2.ModuleDefinition('md1')
+        md1.modules = expected1
+        md2 = sbol2.ModuleDefinition('md1')
+        md2.modules = expected2
+        self.assertTrue(md1.compare(md2))


### PR DESCRIPTION
Property and owned object lists are inherently unordered in
RDF. Handle those unordered lists when comparing SBOLObjects.

Fixes #169 
Fixes #139 