### PR TITLE
Validate validation rules

### DIFF
--- a/sbol2/property.py
+++ b/sbol2/property.py
@@ -69,7 +69,14 @@ class Property(ABC):
             raise ValueError("RDF type must be URIRef or str")
         self._lowerBound = lower_bound
         self._upperBound = upper_bound
-        self._validation_rules = []
+        # Validate validation rules
+        if validation_rules is None:
+            # Some constructors pass None for validation rules
+            # Convert to empty list
+            validation_rules = []
+        for vr in validation_rules:
+            if not callable(vr):
+                raise TypeError('Validation rule %r is not callable' % vr)
         self._validation_rules = validation_rules
         if initial_value is not None:
             self.value = initial_value

--- a/sbol2/test/test_property.py
+++ b/sbol2/test/test_property.py
@@ -1,5 +1,8 @@
 import unittest
 import os
+
+import sbol2
+# backward compatibility
 import sbol2 as sbol
 
 import rdflib
@@ -259,3 +262,15 @@ class TestProperty(unittest.TestCase):
         self.assertEqual(list(md.modules), [m1, m2])
         md.modules.remove(m2.identity)
         self.assertEqual(list(md.modules), [m1])
+
+    def test_validation_rules(self):
+        md = sbol2.ModuleDefinition()
+        with self.assertRaises(TypeError):
+            # No validation rules, so `'AND'` is interpreted
+            # as validation rules
+            tp = sbol2.TextProperty(md, 'http://example.com#logic', '0', '1',
+                                    'AND')
+        # Use an empty list to specify no validation rules
+        tp = sbol2.TextProperty(md, 'http://example.com#logic', '0', '1',
+                                [], 'AND')
+        # Should add a test for callable validation rules


### PR DESCRIPTION
For properties, verify that validation rules are
callable. This will alert users when they omit
validation_rules, which was possible in pySBOL.

Fixes #177 