### PR TITLE
Fix hidden properties and owned object validation

### DIFF
--- a/sbol2/componentdefinition.py
+++ b/sbol2/componentdefinition.py
@@ -5,6 +5,7 @@ from .constants import *
 from .toplevel import TopLevel
 from . import validation
 from .property import OwnedObject, ReferencedObject, URIProperty
+from .sbolerror import SBOLError, SBOLErrorCode
 from .sequence import Sequence
 from .sequenceannotation import SequenceAnnotation
 from .sequenceconstraint import SequenceConstraint
@@ -120,7 +121,7 @@ class ComponentDefinition(TopLevel):
                                   '0', '*', None)
         self.sequence = OwnedObject(self, SBOL_SEQUENCE,
                                     Sequence,
-                                    '0', '1', [validation.libsbol_rule_20])
+                                    '0', '1', [libsbol_rule_20])
         self.sequences = ReferencedObject(self, SBOL_SEQUENCE_PROPERTY,
                                           SBOL_SEQUENCE, '0', '*',
                                           [validation.libsbol_rule_21])
@@ -442,3 +443,22 @@ class ComponentDefinition(TopLevel):
 
     def getTypeURI(self):
         return SBOL_COMPONENT_DEFINITION
+
+
+def libsbol_rule_20(sbol_obj, arg):
+    """Synchronizes ComponentDefinition.sequence with ComponentDefinition.sequences.
+    """
+    if not isinstance(sbol_obj, ComponentDefinition):
+        msg = 'Expected {}, got {}'
+        msg = msg.format(ComponentDefinition.__name__, type(sbol_obj).__name__)
+        raise SBOLError(msg, SBOLErrorCode.SBOL_ERROR_INVALID_ARGUMENT)
+    if arg is None:
+        # Clearing out sequence. What should we do with sequences?
+        # Should we clear sequences?
+        return
+    if not isinstance(arg, Sequence):
+        msg = 'Expected {}, got {}'
+        msg = msg.format(Sequence.__name__, type(arg).__name__)
+        raise SBOLError(msg, SBOLErrorCode.SBOL_ERROR_INVALID_ARGUMENT)
+    if arg.identity not in sbol_obj.sequences:
+        sbol_obj.sequences = [arg.identity]

--- a/sbol2/componentdefinition.py
+++ b/sbol2/componentdefinition.py
@@ -132,6 +132,7 @@ class ComponentDefinition(TopLevel):
         self.sequenceConstraints = OwnedObject(self, SBOL_SEQUENCE_CONSTRAINTS,
                                                SequenceConstraint,
                                                '0', '*', None)
+        self._hidden_properties = [SBOL_SEQUENCE]
 
     @property
     def types(self):

--- a/sbol2/object.py
+++ b/sbol2/object.py
@@ -407,10 +407,16 @@ class SBOLObject:
         graph.add((self._identity.getRawValue(), rdflib.RDF.type,
                    self.rdf_type))
         for typeURI, proplist in self.properties.items():
+            if typeURI in self._hidden_properties:
+                # Skip hidden properties
+                continue
             for prop in proplist:
                 graph.add((self._identity.getRawValue(),
                            typeURI, prop))
         for typeURI, objlist in self.owned_objects.items():
+            if typeURI in self._hidden_properties:
+                # Skip hidden properties
+                continue
             for owned_obj in objlist:
                 graph.add((self._identity.getRawValue(),
                            typeURI, URIRef(owned_obj.identity)))

--- a/sbol2/property.py
+++ b/sbol2/property.py
@@ -198,9 +198,6 @@ class Property(ABC):
         return int(self._upperBound)
 
     def validate(self, arg):
-        if arg is None:
-            # NOTE: Original libSBOL code has commented-out code for this case.
-            raise TypeError("arg cannot be None")
         for validation_rule in self._validation_rules:
             validation_rule(self._sbol_owner, arg)
 
@@ -437,6 +434,7 @@ class OwnedObject(URIProperty):
         """
         super().__init__(property_owner, sbol_uri, lower_bound, upper_bound,
                          validation_rules, first_object)
+        self.validate(first_object)
         if not callable(builder):
             msg = '{!r} object is not callable'
             raise TypeError(msg.format(type(builder)))
@@ -494,7 +492,7 @@ class OwnedObject(URIProperty):
         # Add to parent object
         object_store.append(sbol_obj)
         # Run validation rules
-        # TODO
+        self.validate(sbol_obj)
 
     def __getitem__(self, id):
         if type(id) is int:
@@ -632,7 +630,7 @@ class OwnedObject(URIProperty):
         sbol_obj.update_uri()
 
         # Run validation rules
-        # TODO
+        self.validate(sbol_obj)
 
     @property
     def value(self):

--- a/sbol2/validation.py
+++ b/sbol2/validation.py
@@ -119,19 +119,23 @@ def libsbol_rule_10(sbol_obj, arg):
 
 
 def libsbol_rule_11(sbol_obj, arg):
-    raise NotImplementedError("Not yet implemented")
+    # raise NotImplementedError("Not yet implemented")
+    pass
 
 
 def libsbol_rule_12(sbol_obj, arg):
-    raise NotImplementedError("Not yet implemented")
+    # raise NotImplementedError("Not yet implemented")
+    pass
 
 
 def libsbol_rule_13(sbol_obj, arg):
-    raise NotImplementedError("Not yet implemented")
+    # raise NotImplementedError("Not yet implemented")
+    pass
 
 
 def libsbol_rule_14(sbol_obj, arg):
-    raise NotImplementedError("Not yet implemented")
+    # raise NotImplementedError("Not yet implemented")
+    pass
 
 
 def libsbol_rule_15(sbol_obj, arg):
@@ -139,19 +143,18 @@ def libsbol_rule_15(sbol_obj, arg):
 
 
 def libsbol_rule_16(sbol_obj, arg):
-    raise NotImplementedError("Not yet implemented")
+    # raise NotImplementedError("Not yet implemented")
+    pass
 
 
 def libsbol_rule_17(sbol_obj, arg):
-    raise NotImplementedError("Not yet implemented")
+    # raise NotImplementedError("Not yet implemented")
+    pass
 
 
 def libsbol_rule_18(sbol_obj, arg):
-    raise NotImplementedError("Not yet implemented")
-
-
-def libsbol_rule_20(sbol_obj, arg):
-    raise NotImplementedError("Not yet implemented")
+    # raise NotImplementedError("Not yet implemented")
+    pass
 
 
 def libsbol_rule_21(sbol_obj, arg):
@@ -159,7 +162,8 @@ def libsbol_rule_21(sbol_obj, arg):
 
 
 def libsbol_rule_22(sbol_obj, arg):
-    raise NotImplementedError("Not yet implemented")
+    # raise NotImplementedError("Not yet implemented")
+    pass
 
 
 def libsbol_rule_24(sbol_obj, arg):

--- a/test/test_componentdefinition.py
+++ b/test/test_componentdefinition.py
@@ -229,6 +229,24 @@ class TestComponentDefinitions(unittest.TestCase):
         # We shouldn't find SBOL_SEQUENCE within the component definition
         bad_triple = (cd.identity, sbol2.SBOL_SEQUENCE, None)
         self.assertEqual([], list(graph.triples(bad_triple)))
+        good_triple = (cd.identity, sbol2.SBOL_SEQUENCE_PROPERTY, None)
+        good_triples = list(graph.triples(good_triple))
+        self.assertEqual(len(good_triples), 1)
+        self.assertEqual(good_triples[0], (cd.identity,
+                                           sbol2.SBOL_SEQUENCE_PROPERTY,
+                                           seq.identity))
+
+    def test_sequence_validation(self):
+        cd = sbol2.ComponentDefinition('cd1', sbol2.BIOPAX_DNA)
+        cd.name = 'cd1-name'
+        cd.description = 'cd1-description'
+        seq = sbol2.Sequence('cd1_sequence', 'GCAT')
+        cd.sequence = seq
+        self.assertEqual([seq.identity], cd.sequences)
+
+    @unittest.expectedFailure
+    def test_sequences_validation(self):
+        self.fail('Not yet implemented')
 
 
 if __name__ == '__main__':

--- a/test/test_componentdefinition.py
+++ b/test/test_componentdefinition.py
@@ -213,3 +213,23 @@ class TestComponentDefinitions(unittest.TestCase):
         # the first object is a Cut.
         with self.assertRaises(TypeError):
             sa.locations.getRange()
+
+    def test_hidden_sequence(self):
+        # Sequence should be hidden when writing SBOL
+        doc = sbol2.Document()
+        cd = sbol2.ComponentDefinition('cd1', sbol2.BIOPAX_DNA)
+        cd.name = 'cd1-name'
+        cd.description = 'cd1-description'
+        seq = sbol2.Sequence('cd1_sequence', 'GCAT')
+        cd.sequence = seq
+        doc.addComponentDefinition(cd)
+        xml = doc.writeString()
+        graph = rdflib.Graph()
+        graph.parse(data=xml)
+        # We shouldn't find SBOL_SEQUENCE within the component definition
+        bad_triple = (cd.identity, sbol2.SBOL_SEQUENCE, None)
+        self.assertEqual([], list(graph.triples(bad_triple)))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_componentdefinition.py
+++ b/test/test_componentdefinition.py
@@ -85,12 +85,12 @@ class TestComponentDefinitions(unittest.TestCase):
     def testPrimaryStructureIteration(self):
         list_cd = []
         list_cd_true = ["R0010", "E0040", "B0032", "B0012"]
-        doc = Document()
-        gene = ComponentDefinition("BB0001")
-        promoter = ComponentDefinition("R0010")
-        rbs = ComponentDefinition("B0032")
-        cds = ComponentDefinition("E0040")
-        terminator = ComponentDefinition("B0012")
+        doc = sbol2.Document()
+        gene = sbol2.ComponentDefinition("BB0001")
+        promoter = sbol2.ComponentDefinition("R0010")
+        rbs = sbol2.ComponentDefinition("B0032")
+        cds = sbol2.ComponentDefinition("E0040")
+        terminator = sbol2.ComponentDefinition("B0012")
 
         doc.addComponentDefinition([gene, promoter, rbs, cds, terminator])
 
@@ -107,12 +107,12 @@ class TestComponentDefinitions(unittest.TestCase):
 
     @unittest.expectedFailure
     def testInsertDownstream(self):
-        doc = Document()
-        gene = ComponentDefinition("BB0001")
-        promoter = ComponentDefinition("R0010")
-        rbs = ComponentDefinition("B0032")
-        cds = ComponentDefinition("E0040")
-        terminator = ComponentDefinition("B0012")
+        doc = sbol2.Document()
+        gene = sbol2.ComponentDefinition("BB0001")
+        promoter = sbol2.ComponentDefinition("R0010")
+        rbs = sbol2.ComponentDefinition("B0032")
+        cds = sbol2.ComponentDefinition("E0040")
+        terminator = sbol2.ComponentDefinition("B0012")
 
         doc.addComponentDefinition([gene, promoter, rbs, cds, terminator])
         gene.assemblePrimaryStructure([promoter, rbs, cds])

--- a/test/test_validation.py
+++ b/test/test_validation.py
@@ -1,33 +1,80 @@
 import unittest
 
-import sbol2 as sbol
+import rdflib
+
+import sbol2
 from sbol2.validation import sbol_rule_10202
+from sbol2.componentdefinition import libsbol_rule_20
 
 
 class TestValidation(unittest.TestCase):
 
     def test_is_alphanumeric_or_underscore(self):
         # is alpha
-        self.assertTrue(sbol.is_alphanumeric_or_underscore('A'))
-        self.assertTrue(sbol.is_alphanumeric_or_underscore('a'))
-        self.assertTrue(sbol.is_alphanumeric_or_underscore('M'))
-        self.assertTrue(sbol.is_alphanumeric_or_underscore('m'))
-        self.assertTrue(sbol.is_alphanumeric_or_underscore('Z'))
-        self.assertTrue(sbol.is_alphanumeric_or_underscore('z'))
+        self.assertTrue(sbol2.is_alphanumeric_or_underscore('A'))
+        self.assertTrue(sbol2.is_alphanumeric_or_underscore('a'))
+        self.assertTrue(sbol2.is_alphanumeric_or_underscore('M'))
+        self.assertTrue(sbol2.is_alphanumeric_or_underscore('m'))
+        self.assertTrue(sbol2.is_alphanumeric_or_underscore('Z'))
+        self.assertTrue(sbol2.is_alphanumeric_or_underscore('z'))
         # is numeric
-        self.assertTrue(sbol.is_alphanumeric_or_underscore('0'))
-        self.assertTrue(sbol.is_alphanumeric_or_underscore('3'))
-        self.assertTrue(sbol.is_alphanumeric_or_underscore('9'))
+        self.assertTrue(sbol2.is_alphanumeric_or_underscore('0'))
+        self.assertTrue(sbol2.is_alphanumeric_or_underscore('3'))
+        self.assertTrue(sbol2.is_alphanumeric_or_underscore('9'))
         # is underscore
-        self.assertTrue(sbol.is_alphanumeric_or_underscore('_'))
+        self.assertTrue(sbol2.is_alphanumeric_or_underscore('_'))
         # not alpha or numeric or underscore
-        self.assertFalse(sbol.is_alphanumeric_or_underscore('$'))
-        self.assertFalse(sbol.is_alphanumeric_or_underscore('\n'))
-        self.assertFalse(sbol.is_alphanumeric_or_underscore('-'))
+        self.assertFalse(sbol2.is_alphanumeric_or_underscore('$'))
+        self.assertFalse(sbol2.is_alphanumeric_or_underscore('\n'))
+        self.assertFalse(sbol2.is_alphanumeric_or_underscore('-'))
         # More to ensure the function is exported than anything else
-        self.assertTrue(sbol.is_not_alphanumeric_or_underscore('-'))
-        self.assertFalse(sbol.is_not_alphanumeric_or_underscore('A'))
+        self.assertTrue(sbol2.is_not_alphanumeric_or_underscore('-'))
+        self.assertFalse(sbol2.is_not_alphanumeric_or_underscore('A'))
 
     def test_sbol_rule_10202(self):
         with self.assertRaises(TypeError):
             sbol_rule_10202(None, None)
+
+    def test_libsbol_rule_20_empty(self):
+        # This rule synchronized ComponentDefinition.sequence with
+        # ComponentDefinition.sequences
+        cd = sbol2.ComponentDefinition('cd1')
+        seq = sbol2.Sequence('seq1', 'GCAT')
+        with self.assertRaises(sbol2.SBOLError):
+            libsbol_rule_20('foo', seq)
+        with self.assertRaises(sbol2.SBOLError):
+            libsbol_rule_20(cd, 'foo')
+        cd.sequence = seq
+        self.assertEqual([seq.identity], cd.sequences)
+
+    def test_libsbol_rule_20_empty_set_with(self):
+        # This rule synchronized ComponentDefinition.sequence with
+        # ComponentDefinition.sequences
+        cd = sbol2.ComponentDefinition('cd1')
+        seq = sbol2.Sequence('seq1', 'GCAT')
+        expected = [rdflib.URIRef('http://example.com/foo/1'),
+                    seq.identity,
+                    rdflib.URIRef('https://sbolstandard.org/bar/1')]
+        # Go behind the scenes for the purposes of testing
+        cd.properties[sbol2.SBOL_SEQUENCE_PROPERTY] = expected
+        libsbol_rule_20(cd, seq)
+        # Expect sequences to remain the same, but they've all been
+        # converted to URIRefs
+        self.assertEqual(expected, cd.sequences)
+
+    def test_libsbol_rule_20_empty_set_without(self):
+        # This rule synchronized ComponentDefinition.sequence with
+        # ComponentDefinition.sequences
+        cd = sbol2.ComponentDefinition('cd1')
+        seq = sbol2.Sequence('seq1', 'GCAT')
+        expected = ['http://example.com/foo/1',
+                    'https://sbolstandard.org/bar/1']
+        cd.sequences = expected
+        cd.sequence = seq
+        # Expect sequences to be overwritten to be only
+        # the assigned sequence
+        self.assertEqual([seq.identity], cd.sequences)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
* Honor hidden properties when serializing the document
* Make OwnedObject validation work
* Sync `ComponentDefinition.sequence` -> `ComponentDefinition.sequences`
  * N.B. The reverse synchronization was _not_ implemented. It's harder than expected and is not necessary to support build_request_parser
