### PR TITLE
Round trip all SBOL2 test suite files

### DIFF
--- a/test/test_roundtrip.py
+++ b/test/test_roundtrip.py
@@ -4,22 +4,12 @@ import os
 import unittest
 import tempfile
 import shutil
-import sys
 import rdflib
 import rdflib.compare
 import sbol2 as sbol
 
 MODULE_LOCATION = os.path.dirname(os.path.abspath(__file__))
 SBOL_TEST_SUITE = os.path.join(MODULE_LOCATION, 'SBOLTestSuite')
-TEST_LOC_SBOL2 = os.path.join(SBOL_TEST_SUITE, 'SBOL2_bp')
-FILES_SBOL2 = os.listdir(TEST_LOC_SBOL2)
-FILES_SBOL2.sort()
-TEST_FILES_SBOL2 = []
-for i in FILES_SBOL2:
-    if i.endswith('rdf'):
-        TEST_FILES_SBOL2.append(i)
-    if i.endswith('xml'):
-        TEST_FILES_SBOL2.append(i)
 
 DEBUG_ENV_VAR = 'SBOL_TEST_DEBUG'
 
@@ -135,55 +125,5 @@ class TestRoundTripSBOL2(unittest.TestCase):
             locale.setlocale(locale.LC_ALL, loc)
 
 
-class TestRoundTripFailSBOL2(unittest.TestCase):
-    def setUp(self):
-        # Create temp directory
-        self.temp_out_dir = tempfile.mkdtemp()
-
-    def tearDown(self):
-        # Remove directory after the test
-        shutil.rmtree(self.temp_out_dir)
-
-    def run_round_trip_assert_fail(self, test_file):
-        split_path = os.path.splitext(test_file)
-        self.doc = sbol.Document()   # Document for read and write
-        self.doc.read(os.path.join(TEST_LOC_SBOL2, split_path[0] + split_path[1]))
-        self.doc.write(os.path.join(self.temp_out_dir,
-                                    split_path[0] + '_out' + split_path[1]))
-
-        self.doc2 = sbol.Document()  # Document to compare for equality
-        self.doc2.read(os.path.join(self.temp_out_dir,
-                                    split_path[0] + '_out' + split_path[1]))
-        # Expected to fail
-        self.assertRaises(AssertionError,
-                          lambda: self.assertEqual(self.doc.compare(self.doc2), 1))
-
-
-class SimpleTest(unittest.TestCase):
-    def test_read(self):
-        test_file = str(TEST_FILES_SBOL2[0])
-        split_path = os.path.splitext(test_file)
-        self.doc = sbol.Document()   # Document for read and write
-        self.doc.read(os.path.join(TEST_LOC_SBOL2, split_path[0] + split_path[1]))
-
-
-def runTests(test_list):
-    if test_list is None or test_list == []:
-        return
-    suite_list = []
-    loader = unittest.TestLoader()
-    for test_class in test_list:
-        suite = loader.loadTestsFromTestCase(test_class)
-        suite_list.append(suite)
-
-    full_test_suite = unittest.TestSuite(suite_list)
-
-    unittest.TextTestRunner(verbosity=2, stream=sys.stderr).run(full_test_suite)
-
-
-def runRoundTripTests():
-    runTests([TestRoundTripSBOL2, TestRoundTripFailSBOL2])
-
-
 if __name__ == '__main__':
-    runRoundTripTests()
+    unittest.main()

--- a/test/test_roundtrip.py
+++ b/test/test_roundtrip.py
@@ -37,14 +37,15 @@ class TestRoundTripSBOL2(unittest.TestCase):
         """
         filename = os.path.basename(test_path)
         test2_path = os.path.join(self.temp_out_dir, filename)
+        # Read the document, then write it back to disk
+        doc = sbol2.Document()
+        doc.read(test_path)
+        doc.write(test2_path)
 
-        self.doc = sbol2.Document()   # Document for read and write
-        self.doc.read(test_path)
-        self.doc.write(test2_path)
-
-        self.doc2 = sbol2.Document()  # Document to compare for equality
-        self.doc2.read(test2_path)
-        self.assertTrue(self.doc.compare(self.doc2))
+        # Read the newly written document and compare results
+        doc2 = sbol2.Document()
+        doc2.read(test2_path)
+        self.assertTrue(doc.compare(doc2))
 
         # Now compare the graphs in RDF
         g1 = rdflib.Graph()

--- a/test/test_roundtrip.py
+++ b/test/test_roundtrip.py
@@ -6,7 +6,7 @@ import tempfile
 import shutil
 import rdflib
 import rdflib.compare
-import sbol2 as sbol
+import sbol2
 
 MODULE_LOCATION = os.path.dirname(os.path.abspath(__file__))
 SBOL_TEST_SUITE = os.path.join(MODULE_LOCATION, 'SBOLTestSuite')
@@ -19,7 +19,7 @@ class TestRoundTripSBOL2(unittest.TestCase):
     def setUp(self):
         # Create temp directory
         self.temp_out_dir = tempfile.mkdtemp()
-        self.logger = logging.getLogger('sbol.test')
+        self.logger = logging.getLogger('sbol2.test')
         if not self.logger.hasHandlers():
             logging.basicConfig()
         if DEBUG_ENV_VAR in os.environ:
@@ -38,11 +38,11 @@ class TestRoundTripSBOL2(unittest.TestCase):
         filename = os.path.basename(test_path)
         test2_path = os.path.join(self.temp_out_dir, filename)
 
-        self.doc = sbol.Document()   # Document for read and write
+        self.doc = sbol2.Document()   # Document for read and write
         self.doc.read(test_path)
         self.doc.write(test2_path)
 
-        self.doc2 = sbol.Document()  # Document to compare for equality
+        self.doc2 = sbol2.Document()  # Document to compare for equality
         self.doc2.read(test2_path)
         self.assertTrue(self.doc.compare(self.doc2))
 


### PR DESCRIPTION
Add SBOL2_bp, SBOL2_ic, and SBOL2_nc directories
to the round trip tests.

Fixes #208