### PR TITLE
Implement Document.convert()

### DIFF
--- a/examples/data/BBa_I0462.xml
+++ b/examples/data/BBa_I0462.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0" ?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:sbol="http://sbols.org/v2#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:prov="http://www.w3.org/ns/prov#" xmlns:om="http://www.ontology-of-units-of-measure.org/resource/om-2/">
+  <sbol:ComponentDefinition rdf:about="http://www.async.ece.utah.edu/BBa_C0062">
+    <sbol:persistentIdentity rdf:resource="http://www.async.ece.utah.edu/BBa_C0062"/>
+    <sbol:displayId>BBa_C0062</sbol:displayId>
+    <prov:wasDerivedFrom rdf:resource="http://partsregistry.org/Part:BBa_C0062"/>
+    <dcterms:title>luxR</dcterms:title>
+    <sbol:type rdf:resource="http://www.biopax.org/release/biopax-level3.owl#DnaRegion"/>
+    <sbol:type rdf:resource="http://identifiers.org/so/SO:0000987"/>
+    <sbol:role rdf:resource="http://identifiers.org/so/SO:0000316"/>
+  </sbol:ComponentDefinition>
+  <sbol:ComponentDefinition rdf:about="http://www.async.ece.utah.edu/BBa_B0015">
+    <sbol:persistentIdentity rdf:resource="http://www.async.ece.utah.edu/BBa_B0015"/>
+    <sbol:displayId>BBa_B0015</sbol:displayId>
+    <prov:wasDerivedFrom rdf:resource="http://partsregistry.org/Part:BBa_B0015"/>
+    <dcterms:title>B0015</dcterms:title>
+    <sbol:type rdf:resource="http://www.biopax.org/release/biopax-level3.owl#DnaRegion"/>
+    <sbol:type rdf:resource="http://identifiers.org/so/SO:0000987"/>
+    <sbol:role rdf:resource="http://identifiers.org/so/SO:0000141"/>
+  </sbol:ComponentDefinition>
+  <sbol:ComponentDefinition rdf:about="http://www.async.ece.utah.edu/BBa_B0034">
+    <sbol:persistentIdentity rdf:resource="http://www.async.ece.utah.edu/BBa_B0034"/>
+    <sbol:displayId>BBa_B0034</sbol:displayId>
+    <prov:wasDerivedFrom rdf:resource="http://partsregistry.org/Part:BBa_B0034"/>
+    <dcterms:title>B0034</dcterms:title>
+    <sbol:type rdf:resource="http://www.biopax.org/release/biopax-level3.owl#DnaRegion"/>
+    <sbol:type rdf:resource="http://identifiers.org/so/SO:0000987"/>
+    <sbol:role rdf:resource="http://identifiers.org/so/SO:0000139"/>
+  </sbol:ComponentDefinition>
+  <sbol:ComponentDefinition rdf:about="http://www.async.ece.utah.edu/BBa_I0462">
+    <sbol:persistentIdentity rdf:resource="http://www.async.ece.utah.edu/BBa_I0462"/>
+    <sbol:displayId>BBa_I0462</sbol:displayId>
+    <prov:wasDerivedFrom rdf:resource="http://partsregistry.org/Part:BBa_I0462"/>
+    <dcterms:title>I0462</dcterms:title>
+    <dcterms:description>LuxR protein generator</dcterms:description>
+    <sbol:type rdf:resource="http://www.biopax.org/release/biopax-level3.owl#DnaRegion"/>
+    <sbol:type rdf:resource="http://identifiers.org/so/SO:0000987"/>
+    <sbol:role rdf:resource="http://identifiers.org/so/SO:0000804"/>
+    <sbol:component>
+      <sbol:Component rdf:about="http://www.async.ece.utah.edu/BBa_I0462/BBa_B0015">
+        <sbol:persistentIdentity rdf:resource="http://www.async.ece.utah.edu/BBa_I0462/BBa_B0015"/>
+        <sbol:displayId>BBa_B0015</sbol:displayId>
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://www.async.ece.utah.edu/BBa_B0015"/>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://www.async.ece.utah.edu/BBa_I0462/BBa_C0062">
+        <sbol:persistentIdentity rdf:resource="http://www.async.ece.utah.edu/BBa_I0462/BBa_C0062"/>
+        <sbol:displayId>BBa_C0062</sbol:displayId>
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://www.async.ece.utah.edu/BBa_C0062"/>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:component>
+      <sbol:Component rdf:about="http://www.async.ece.utah.edu/BBa_I0462/BBa_B0034">
+        <sbol:persistentIdentity rdf:resource="http://www.async.ece.utah.edu/BBa_I0462/BBa_B0034"/>
+        <sbol:displayId>BBa_B0034</sbol:displayId>
+        <sbol:access rdf:resource="http://sbols.org/v2#public"/>
+        <sbol:definition rdf:resource="http://www.async.ece.utah.edu/BBa_B0034"/>
+      </sbol:Component>
+    </sbol:component>
+    <sbol:sequenceAnnotation>
+      <sbol:SequenceAnnotation rdf:about="http://www.async.ece.utah.edu/BBa_I0462/BBa_B0015_annotation">
+        <sbol:persistentIdentity rdf:resource="http://www.async.ece.utah.edu/BBa_I0462/BBa_B0015_annotation"/>
+        <sbol:displayId>BBa_B0015_annotation</sbol:displayId>
+        <prov:wasDerivedFrom rdf:resource="http://sbols.org/anot#3456789"/>
+        <sbol:location>
+          <sbol:Range rdf:about="http://www.async.ece.utah.edu/BBa_I0462/BBa_B0015_annotation/range">
+            <sbol:persistentIdentity rdf:resource="http://www.async.ece.utah.edu/BBa_I0462/BBa_B0015_annotation/range"/>
+            <sbol:displayId>range</sbol:displayId>
+            <sbol:start>808</sbol:start>
+            <sbol:end>936</sbol:end>
+            <sbol:orientation rdf:resource="http://sbols.org/v2#inline"/>
+          </sbol:Range>
+        </sbol:location>
+        <sbol:component rdf:resource="http://www.async.ece.utah.edu/BBa_I0462/BBa_B0015"/>
+      </sbol:SequenceAnnotation>
+    </sbol:sequenceAnnotation>
+    <sbol:sequenceAnnotation>
+      <sbol:SequenceAnnotation rdf:about="http://www.async.ece.utah.edu/BBa_I0462/BBa_C0062_annotation">
+        <sbol:persistentIdentity rdf:resource="http://www.async.ece.utah.edu/BBa_I0462/BBa_C0062_annotation"/>
+        <sbol:displayId>BBa_C0062_annotation</sbol:displayId>
+        <prov:wasDerivedFrom rdf:resource="http://sbols.org/anot#2345678"/>
+        <sbol:location>
+          <sbol:Range rdf:about="http://www.async.ece.utah.edu/BBa_I0462/BBa_C0062_annotation/range">
+            <sbol:persistentIdentity rdf:resource="http://www.async.ece.utah.edu/BBa_I0462/BBa_C0062_annotation/range"/>
+            <sbol:displayId>range</sbol:displayId>
+            <sbol:start>19</sbol:start>
+            <sbol:end>774</sbol:end>
+            <sbol:orientation rdf:resource="http://sbols.org/v2#inline"/>
+          </sbol:Range>
+        </sbol:location>
+        <sbol:component rdf:resource="http://www.async.ece.utah.edu/BBa_I0462/BBa_C0062"/>
+      </sbol:SequenceAnnotation>
+    </sbol:sequenceAnnotation>
+    <sbol:sequenceAnnotation>
+      <sbol:SequenceAnnotation rdf:about="http://www.async.ece.utah.edu/BBa_I0462/BBa_B0034_annotation">
+        <sbol:persistentIdentity rdf:resource="http://www.async.ece.utah.edu/BBa_I0462/BBa_B0034_annotation"/>
+        <sbol:displayId>BBa_B0034_annotation</sbol:displayId>
+        <prov:wasDerivedFrom rdf:resource="http://sbols.org/anot#1234567"/>
+        <sbol:location>
+          <sbol:Range rdf:about="http://www.async.ece.utah.edu/BBa_I0462/BBa_B0034_annotation/range">
+            <sbol:persistentIdentity rdf:resource="http://www.async.ece.utah.edu/BBa_I0462/BBa_B0034_annotation/range"/>
+            <sbol:displayId>range</sbol:displayId>
+            <sbol:start>1</sbol:start>
+            <sbol:end>12</sbol:end>
+            <sbol:orientation rdf:resource="http://sbols.org/v2#inline"/>
+          </sbol:Range>
+        </sbol:location>
+        <sbol:component rdf:resource="http://www.async.ece.utah.edu/BBa_I0462/BBa_B0034"/>
+      </sbol:SequenceAnnotation>
+    </sbol:sequenceAnnotation>
+    <sbol:sequence rdf:resource="http://www.async.ece.utah.edu/seq_d23749adb3a7e0e2f09168cb7267a6113b238973"/>
+  </sbol:ComponentDefinition>
+  <sbol:Sequence rdf:about="http://www.async.ece.utah.edu/seq_d23749adb3a7e0e2f09168cb7267a6113b238973">
+    <sbol:persistentIdentity rdf:resource="http://www.async.ece.utah.edu/seq_d23749adb3a7e0e2f09168cb7267a6113b238973"/>
+    <sbol:displayId>seq_d23749adb3a7e0e2f09168cb7267a6113b238973</sbol:displayId>
+    <prov:wasDerivedFrom rdf:resource="http://sbols.org/seq#d23749adb3a7e0e2f09168cb7267a6113b238973"/>
+    <sbol:elements>aaagaggagaaatactagatgaaaaacataaatgccgacgacacatacagaataattaataaaattaaagcttgtagaagcaataatgatattaatcaatgcttatctgatatgactaaaatggtacattgtgaatattatttactcgcgatcatttatcctcattctatggttaaatctgatatttcaatcctagataattaccctaaaaaatggaggcaatattatgatgacgctaatttaataaaatatgatcctatagtagattattctaactccaatcattcaccaattaattggaatatatttgaaaacaatgctgtaaataaaaaatctccaaatgtaattaaagaagcgaaaacatcaggtcttatcactgggtttagtttccctattcatacggctaacaatggcttcggaatgcttagttttgcacattcagaaaaagacaactatatagatagtttatttttacatgcgtgtatgaacataccattaattgttccttctctagttgataattatcgaaaaataaatatagcaaataataaatcaaacaacgatttaaccaaaagagaaaaagaatgtttagcgtgggcatgcgaaggaaaaagctcttgggatatttcaaaaatattaggttgcagtgagcgtactgtcactttccatttaaccaatgcgcaaatgaaactcaatacaacaaaccgctgccaaagtatttctaaagcaattttaacaggagcaattgattgcccatactttaaaaattaataacactgatagtgctagtgtagatcactactagagccaggcatcaaataaaacgaaaggctcagtcgaaagactgggcctttcgttttatctgttgtttgtcggtgaacgctctctactagagtcacactggctcaccttcgggtgggcctttctgcgtttata</sbol:elements>
+    <sbol:encoding rdf:resource="http://www.chem.qmul.ac.uk/iubmb/misc/naseq.html"/>
+  </sbol:Sequence>
+</rdf:RDF>

--- a/examples/sbol_to_genbank.py
+++ b/examples/sbol_to_genbank.py
@@ -1,0 +1,11 @@
+import sbol2
+
+# This example uses the SBOL Validator (http://synbiodex.github.io/SBOL-Validator/)
+# to convert an SBOL document to a GenBank file.
+
+# Create a new Document and read the SBOL file
+doc = sbol2.Document('data/BBa_I0462.xml')
+
+# Export the document in 'GenBank' format.
+# Write the output to the destination file.
+doc.exportToFormat('GenBank', 'BBa_I0462.gb')

--- a/sbol2/document.py
+++ b/sbol2/document.py
@@ -755,69 +755,22 @@ class Document(Identified):
             for s, p, o in self.graph:
                 self.logger.debug('Graph contains: %r', (s, p, o))
 
-    def validation_options(self):
-        # Config validation options that have boolean values
-        config_options = [
-            ConfigOptions.CHECK_BEST_PRACTICES,
-            ConfigOptions.CHECK_COMPLETENESS,
-            ConfigOptions.CHECK_URI_COMPLIANCE,
-            ConfigOptions.DIFF_FILE_NAME,
-            ConfigOptions.FAIL_ON_FIRST_ERROR,
-            ConfigOptions.INSERT_TYPE,
-            ConfigOptions.LANGUAGE,
-            ConfigOptions.MAIN_FILE_NAME,
-            ConfigOptions.PROVIDE_DETAILED_STACK_TRACE,
-            ConfigOptions.SUBSET_URI,
-            ConfigOptions.TEST_EQUALITY,
-            ConfigOptions.URI_PREFIX,
-            ConfigOptions.VERSION
-        ]
-        options = {}
-        for opt in config_options:
-            options[opt.value] = Config.getOption(opt)
-        return dict(options=options)
-
-    # Online validation #
-    def request_validation(self, sbol_str):
-        json_request = self.validation_options()
-        return_file = Config.getOption(ConfigOptions.RETURN_FILE)
-        json_request[ConfigOptions.RETURN_FILE.value] = return_file
-        json_request['main_file'] = sbol_str
-
-        headers = {
-            'Accept': 'application/json',
-            'Content-Type': 'application/json',
-            'charsets': 'utf-8'
-        }
-
-        validator_url = Config.getOption(ConfigOptions.VALIDATOR_URL)
-
-        # Send the request to the online validation tool
-        response = requests.post(validator_url,
-                                 json=json_request,
-                                 headers=headers)
-        if response:
-            info = response.json()
-            if info['valid']:
-                result = "Valid."
-            else:
-                result = "Invalid."
-            errors = ' '.join(info['errors'])
-            if errors:
-                result = ' '.join([result, errors])
-            return result
-        else:
-            msg = 'Cannot validate online. HTTP post request failed with code {}: {}'
-            msg = msg.format(response.status_code, response.content)
-            raise SBOLError(msg, SBOLErrorCode.SBOL_ERROR_BAD_HTTP_REQUEST)
-
     def validate(self):
         """
         Run validation on this Document via the online validation tool.
 
         :return: A string containing a message with the validation results
+        :rtype: str
         """
-        return self.request_validation(self.writeString())
+        response = validate(self, config.options)
+        if response['valid']:
+            result = "Valid."
+        else:
+            result = "Invalid."
+        errors = ' '.join(response['errors'])
+        if errors:
+            result = ' '.join([result, errors])
+        return result
 
     def size(self):
         """

--- a/sbol2/document.py
+++ b/sbol2/document.py
@@ -2,6 +2,8 @@ import collections.abc
 import logging
 import os
 import posixpath
+from typing import Any, Mapping, Union
+import warnings
 
 import rdflib
 
@@ -965,3 +967,84 @@ class Document(Identified):
         if version is None:
             version = self.version
         return super().copy(target_doc, target_namespace, version)
+
+    def exportToFormat(self, language: str, output_path: str):
+        # Copy the global config options. Shallow copy is ok because values
+        # are either bool or str.
+        options = config.options.copy()
+        options[ConfigOptions.LANGUAGE.value] = language
+        # We always want the return file
+        options[ConfigOptions.RETURN_FILE.value] = True
+        response = validate(self, options)
+
+        # What should we be expecting from the validator?
+        # Can we tell if there was an error?
+        # Is it if there are any errors? Or if 'Conversion failed.' is one of the errors?
+        # Or if response['result'] is not empty?
+        if response['errors'][0]:
+            msg = ' '.join(response['errors'])
+            raise SBOLError(msg, SBOLErrorCode.SBOL_ERROR_INVALID_ARGUMENT)
+        if not response['result']:
+            msg = 'Validator returned no content'
+            raise SBOLError(msg, SBOLErrorCode.SBOL_ERROR_INVALID_ARGUMENT)
+        # write the result to the desired output path
+        with open(output_path, 'w') as fp:
+            fp.write(response['result'])
+
+    def convert(self, language, output_path):
+        warnings.warn('Document.convert is now Document.exportToFormat',
+                      DeprecationWarning)
+        self.exportToFormat(language, output_path)
+
+
+def _make_validation_request(options: Mapping[str, Union[bool, str]]):
+    config_options = [
+        config.ConfigOptions.CHECK_BEST_PRACTICES.value,
+        config.ConfigOptions.CHECK_COMPLETENESS.value,
+        config.ConfigOptions.CHECK_URI_COMPLIANCE.value,
+        config.ConfigOptions.DIFF_FILE_NAME.value,
+        config.ConfigOptions.FAIL_ON_FIRST_ERROR.value,
+        config.ConfigOptions.INSERT_TYPE.value,
+        config.ConfigOptions.LANGUAGE.value,
+        config.ConfigOptions.MAIN_FILE_NAME.value,
+        config.ConfigOptions.PROVIDE_DETAILED_STACK_TRACE.value,
+        config.ConfigOptions.SUBSET_URI.value,
+        config.ConfigOptions.TEST_EQUALITY.value,
+        config.ConfigOptions.URI_PREFIX.value,
+        config.ConfigOptions.VERSION.value
+    ]
+    request_options = {}
+    for key in config_options:
+        request_options[key] = options[key]
+    return dict(options=request_options)
+
+
+def validate(doc: Document, options: Mapping[str, Any]):
+    """
+    :rtype: Dict[str, Any]
+    """
+    return_file_key = config.ConfigOptions.RETURN_FILE.value
+    validator_key = config.ConfigOptions.VALIDATOR_URL.value
+    json_request = _make_validation_request(options)
+    # We always want the return file
+    json_request[return_file_key] = options[return_file_key]
+    json_request['main_file'] = doc.writeString()
+
+    headers = {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json',
+        'charsets': 'utf-8'
+    }
+
+    validator_url = options[validator_key]
+
+    # Send the request to the online validation tool
+    response = requests.post(validator_url,
+                             json=json_request,
+                             headers=headers)
+    if response:
+        return response.json()
+    else:
+        msg = 'Validation failure. HTTP post request failed with code {}: {}'
+        msg = msg.format(response.status_code, response.content)
+        raise SBOLError(msg, SBOLErrorCode.SBOL_ERROR_BAD_HTTP_REQUEST)

--- a/test/test_document.py
+++ b/test/test_document.py
@@ -344,12 +344,6 @@ class TestDocument(unittest.TestCase):
         expected = 'Valid.'
         self.assertEqual(result, expected)
 
-    def test_validate_invalid(self):
-        doc = sbol2.Document()
-        result = doc.request_validation('mumbo jumbo')
-        expected = 'Invalid.'
-        self.assertEqual(result[:len(expected)], expected)
-
     def test_validate_bad_url(self):
         sbol2.Config.setOption(sbol2.ConfigOptions.VALIDATOR_URL,
                                self.validator_url + 'foo/bar')


### PR DESCRIPTION
* Add `Document.convert()`
  - This method is deprecated because it has been removed from libSBOL/pySBOL
* Add `Document.exportToFormat()`
  - This is the new `Document.convert()` in libSBOL/pySBOL
* Refactor calls to the validator so they go through common plumbing

Fixes #189