### PR TITLE
Add Document.addAttachment()

### DIFF
--- a/sbol2/attachment.py
+++ b/sbol2/attachment.py
@@ -1,13 +1,13 @@
 from .toplevel import TopLevel
 from .constants import *
-from rdflib import URIRef
 from .property import URIProperty, LiteralProperty
 
 
 class Attachment(TopLevel):
 
-    def __init__(self, type_uri=SBOL_ATTACHMENT, uri=URIRef("example"),
-                 version=VERSION_STRING, source=''):
+    def __init__(self, uri=URIRef("example"),
+                 *, type_uri=SBOL_ATTACHMENT, version=VERSION_STRING,
+                 source=''):
         super().__init__(type_uri, uri, version)
         self._source = URIProperty(self, SBOL_SOURCE, '1', '1', [], source)
         self._format = LiteralProperty(self, SBOL_URI + '#format', '0', '1', [])

--- a/sbol2/document.py
+++ b/sbol2/document.py
@@ -315,6 +315,15 @@ class Document(Identified):
         else:
             self.add(implementation)
 
+    def addAttachment(self, attachment):
+        """Add an attachment to this document.
+        """
+        if isinstance(attachment, collections.abc.Iterable):
+            for a in attachment:
+                self.add(a)
+        else:
+            self.add(attachment)
+
     def create(self, uri):
         """
         Creates another SBOL object derived from TopLevel

--- a/test/test_attachment.py
+++ b/test/test_attachment.py
@@ -9,6 +9,13 @@ class TestAttachment(unittest.TestCase):
         # Ensure Attachment is exported from sbol2
         self.assertIn('Attachment', dir(sbol2))
 
+    def test_type_uri(self):
+        # Test that after construction the attachment has the correct URI.
+        # This was a problem until the arguments to the constructor were
+        # rearranged.
+        test_attach = sbol2.Attachment("TEST")
+        self.assertEqual(sbol2.SBOL_ATTACHMENT, test_attach.rdf_type)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_document.py
+++ b/test/test_document.py
@@ -388,6 +388,13 @@ class TestDocument(unittest.TestCase):
         # The component is not top level, so doesn't get added
         self.assertEqual(2, len(doc))
 
+    def test_add_attachment(self):
+        doc = sbol2.Document()
+        test_attach = sbol2.Attachment("TEST")
+        doc.addAttachment(test_attach)
+        self.assertEqual(1, len(doc.attachments))
+        self.assertTrue(test_attach.compare(doc.attachments[0]))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Also fix up the Attachment constructor so that
a URI argument does not overwrite the type_uri.

Fixes #213