### PR TITLE
Change logger to 'sbol2'

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+# Include examples
+graft examples

--- a/examples/sbol2_logging.py
+++ b/examples/sbol2_logging.py
@@ -1,0 +1,15 @@
+import logging
+
+import sbol2
+
+# This example shows how to configure logging for sbol2
+
+
+# Configure the Python logging system
+logging.basicConfig()
+
+# Set the 'sbol2' logger to debug level
+logging.getLogger('sbol2').setLevel(logging.DEBUG)
+
+# This will generate lots of debug logging
+doc = sbol2.Document('data/BBa_I0462.xml')

--- a/sbol2/object.py
+++ b/sbol2/object.py
@@ -116,7 +116,7 @@ class SBOLObject:
 
     @property
     def logger(self):
-        logger = logging.getLogger('sbol')
+        logger = logging.getLogger('sbol2')
         if not logger.hasHandlers():
             # If there are no handlers, nobody has initialized
             # logging.  Configure logging here so we have a chance of

--- a/sbol2/partshop.py
+++ b/sbol2/partshop.py
@@ -47,7 +47,7 @@ class PartShop:
 
     @property
     def logger(self):
-        logger = logging.getLogger('sbol')
+        logger = logging.getLogger('sbol2')
         if not logger.hasHandlers():
             # If there are no handlers, nobody has initialized
             # logging.  Configure logging here so we have a chance of

--- a/sbol2/property.py
+++ b/sbol2/property.py
@@ -83,7 +83,7 @@ class Property(ABC):
 
     @property
     def logger(self):
-        logger = logging.getLogger('sbol')
+        logger = logging.getLogger('sbol2')
         if not logger.hasHandlers():
             # If there are no handlers, nobody has initialized
             # logging.  Configure logging here so we have a chance of

--- a/test/test_tutorial.py
+++ b/test/test_tutorial.py
@@ -4,7 +4,7 @@ import unittest
 
 import sbol2 as sbol
 
-LOGGER_NAME = 'sbol.test'
+LOGGER_NAME = 'sbol2.test'
 DEBUG_ENV_VAR = 'SBOL_TEST_DEBUG'
 MY_DIR = os.path.dirname(os.path.abspath(__file__))
 PARTS_FILE = os.path.join(MY_DIR, 'resources', 'tutorial', 'parts.xml')


### PR DESCRIPTION
Change the logger name to match the new package
name. Add an example of how to configure the
sbol2 logger. Include examples in source distribution.

Fixes #184 