### PR TITLE
Implemented specialized behavior for singleton OwnedObjects

### DIFF
--- a/sbol2/object.py
+++ b/sbol2/object.py
@@ -471,7 +471,7 @@ class SBOLObject:
             result = result.value
         elif isinstance(result, OwnedObject):
             sbol_property = object.__getattribute__(self, name)
-            if sbol_property.getUpperBound() == '1':
+            if sbol_property.upper_bound == 1:
                 result = sbol_property.get()
             else:
                 result = sbol_property

--- a/sbol2/object.py
+++ b/sbol2/object.py
@@ -469,6 +469,12 @@ class SBOLObject:
             # Convert the ReferencedObject to a value instead of
             # returning the ReferencedObject itself
             result = result.value
+        elif isinstance(result, OwnedObject):
+            sbol_property = object.__getattribute__(self, name)
+            if sbol_property.getUpperBound() == '1':
+                result = sbol_property.get()
+            else:
+                result = sbol_property
         return result
 
     def _is_owned_object(self, name):

--- a/sbol2/property.py
+++ b/sbol2/property.py
@@ -597,7 +597,7 @@ class OwnedObject(URIProperty):
                 if obj.identity == compliant_uri:
                     return obj
 
-    def get(self, uri):
+    def get(self, uri = ''):
         # TODO: orig getter contains a size check when uri is a constant string
         if uri == '':
             return self._sbol_owner.owned_objects[self._rdf_type][0]

--- a/sbol2/property.py
+++ b/sbol2/property.py
@@ -597,7 +597,7 @@ class OwnedObject(URIProperty):
                 if obj.identity == compliant_uri:
                     return obj
 
-    def get(self, uri = ''):
+    def get(self, uri=''):
         # TODO: orig getter contains a size check when uri is a constant string
         if uri == '':
             return self._sbol_owner.owned_objects[self._rdf_type][0]

--- a/test/test_property.py
+++ b/test/test_property.py
@@ -144,8 +144,20 @@ class TestProperty(unittest.TestCase):
 
     def test_owned_object_singleton(self):
         cd = sbol.ComponentDefinition('cd')
-        cd.sequence = sbol.Sequence('seq')
-        self.assertEqual(type(cd.sequence), sbol.Sequence)
+        annotation_uri = rdflib.URIRef('http://examples.org#annotation_property')
+        cd.annotation = sbol.property.OwnedObject(cd, annotation_uri, sbol.Identified,
+                                                  '0', '1', None)
+        cd.annotation = sbol.Identified('foo')
+        self.assertEqual(type(cd.annotation), sbol.Identified)
+
+    def test_owned_object_multiple(self):
+        cd = sbol.ComponentDefinition('cd')
+        annotation_uri = rdflib.URIRef('http://examples.org#annotation_property')
+        cd.annotations = sbol.property.OwnedObject(cd, annotation_uri, sbol.Identified,
+                                                   '0', '*', None)
+        cd.annotations.add(sbol.Identified('foo_0'))
+        cd.annotations.add(sbol.Identified('foo_1'))
+        self.assertEqual(type(cd.annotations), sbol.property.OwnedObject)
 
     def test_owned_object_find(self):
         doc = sbol.Document()

--- a/test/test_property.py
+++ b/test/test_property.py
@@ -142,6 +142,11 @@ class TestProperty(unittest.TestCase):
         tp.value = expected
         self.assertEqual(tp.value, [])
 
+    def test_owned_object_singleton(self):
+        cd = sbol.ComponentDefinition('cd')
+        cd.sequence = sbol.Sequence('seq')
+        self.assertEqual(type(cd.sequence), sbol.Sequence)
+
     def test_owned_object_find(self):
         doc = sbol.Document()
         md = doc.moduleDefinitions.create('foo')


### PR DESCRIPTION
`OwnedObject` properties with max cardinality '1' return an object rather than a dictionary-like interface
Implemented this special behavior in `SBOLObject` `__getattribute__` method