### PR TITLE
Return None if OwnedObject is not set

### DIFF
--- a/sbol2/object.py
+++ b/sbol2/object.py
@@ -472,7 +472,10 @@ class SBOLObject:
         elif isinstance(result, OwnedObject):
             sbol_property = object.__getattribute__(self, name)
             if sbol_property.upper_bound == 1:
-                result = sbol_property.get()
+                if len(sbol_property):
+                    result = sbol_property[0]
+                else:
+                    result = None
             else:
                 result = sbol_property
         return result

--- a/test/test_property.py
+++ b/test/test_property.py
@@ -147,7 +147,7 @@ class TestProperty(unittest.TestCase):
         annotation_uri = rdflib.URIRef('http://examples.org#annotation_property')
         cd.annotation = sbol.property.OwnedObject(cd, annotation_uri, sbol.Identified,
                                                   '0', '1', None)
-        self.assertIs(cd.annotation, None)
+        self.assertIsNone(cd.annotation)
         cd.annotation = sbol.Identified('foo')
         self.assertEqual(type(cd.annotation), sbol.Identified)
 

--- a/test/test_property.py
+++ b/test/test_property.py
@@ -147,6 +147,7 @@ class TestProperty(unittest.TestCase):
         annotation_uri = rdflib.URIRef('http://examples.org#annotation_property')
         cd.annotation = sbol.property.OwnedObject(cd, annotation_uri, sbol.Identified,
                                                   '0', '1', None)
+        self.assertIs(cd.annotation, None)
         cd.annotation = sbol.Identified('foo')
         self.assertEqual(type(cd.annotation), sbol.Identified)
 
@@ -155,6 +156,7 @@ class TestProperty(unittest.TestCase):
         annotation_uri = rdflib.URIRef('http://examples.org#annotation_property')
         cd.annotations = sbol.property.OwnedObject(cd, annotation_uri, sbol.Identified,
                                                    '0', '*', None)
+        self.assertEqual(type(cd.annotations), sbol.property.OwnedObject)
         cd.annotations.add(sbol.Identified('foo_0'))
         cd.annotations.add(sbol.Identified('foo_1'))
         self.assertEqual(type(cd.annotations), sbol.property.OwnedObject)


### PR DESCRIPTION
- If a singleton `OwnedObject` is not set (e.g., `ComponentDefinition.sequence`), it will now return None;  before the fix it was throwing an IndexError
- there's now a test for this, which was missing in the previous PR