### PR TITLE
Fix hidden property adder

### DIFF
--- a/sbol2/property.py
+++ b/sbol2/property.py
@@ -476,10 +476,19 @@ class OwnedObject(URIProperty):
         if self._sbol_owner is None:
             # Just silently do nothing?
             return
+
+        # If this is a top level object, add it and all its children recursively to the
+        # Document. (With some additional refactoring, this could probably all be handled
+        # from this method, thus eliminating need for a separate Document adder method)
         if sbol_obj.is_top_level() and self._sbol_owner.doc is not None:
-            # Is this really all we need to do?
             self._sbol_owner.doc.add(sbol_obj)
-            return
+            # If a property is hidden, don't return yet, because it still needs to be
+            # added as a child object. (By definition, a hidden owned object can be
+            # accessed from both the Document top level and as a child of another top
+            # level)
+            if not self._isHidden():
+                return
+
         # Not top level, add to the attribute
         object_store = self._sbol_owner.owned_objects[self._rdf_type]
         if sbol_obj in object_store:

--- a/test/test_componentdefinition.py
+++ b/test/test_componentdefinition.py
@@ -243,12 +243,16 @@ class TestComponentDefinitions(unittest.TestCase):
         cd.sequence = seq
         self.assertEqual([cd.sequence.identity], cd.sequences)
 
-        # now test whether this works in the context of a Document
+
+    def test_hidden_property_adder(self):
+        # Assignment of a TopLevel object to a hidden property (in this case
+        # assigning a Sequence object to the sequence property) should
+        # simultaneously add that object to the Document top level
         doc = sbol2.Document()
-        cd = doc.componentDefinitions.create('cd1')
-        cd.sequence = seq
+        cd = doc.componentDefinitions.create('cd')
+        cd.sequence = sbol2.Sequence('seq')
         self.assertIsNotNone(cd.sequence)
-        self.assertEqual([cd.sequence.identity], cd.sequences)
+        self.assertIs(cd.sequence, doc.getSequence(cd.sequence.identity))
 
     @unittest.expectedFailure
     def test_sequences_validation(self):

--- a/test/test_componentdefinition.py
+++ b/test/test_componentdefinition.py
@@ -237,12 +237,18 @@ class TestComponentDefinitions(unittest.TestCase):
                                            seq.identity))
 
     def test_sequence_validation(self):
+        # sequence and sequences should be synced up
         cd = sbol2.ComponentDefinition('cd1', sbol2.BIOPAX_DNA)
-        cd.name = 'cd1-name'
-        cd.description = 'cd1-description'
         seq = sbol2.Sequence('cd1_sequence', 'GCAT')
         cd.sequence = seq
-        self.assertEqual([seq.identity], cd.sequences)
+        self.assertEqual([cd.sequence.identity], cd.sequences)
+
+        # now test whether this works in the context of a Document
+        doc = sbol2.Document()
+        cd = doc.componentDefinitions.create('cd1')
+        cd.sequence = seq
+        self.assertIsNotNone(cd.sequence)
+        self.assertEqual([cd.sequence.identity], cd.sequences)
 
     @unittest.expectedFailure
     def test_sequences_validation(self):


### PR DESCRIPTION
- Hidden owned objects can be added simultaneously to the `Document` top level and as a child of another top level object (e.g., `ComponentDefinition.sequence`)