### PR TITLE
Implement PartShop.search

### DIFF
--- a/sbol2/partshop.py
+++ b/sbol2/partshop.py
@@ -346,7 +346,7 @@ class PartShop:
         if self.key:
             headers['X-authorization'] = self.key
 
-        self.logger.warning('search query: %s', url)
+        self.logger.info('search query: %s', url)
         response = requests.get(url, headers=headers)
         if not response:
             # Something went wrong
@@ -380,8 +380,6 @@ class PartShop:
             search_text = f"'{search_text}'"
         query[parseClassName(property_uri)] = search_text
         query = urllib.parse.urlencode(query)
-        # Unquote then requote to escape the equal signs
-        query = urllib.parse.quote(urllib.parse.unquote(query))
         params = dict(offset=offset, limit=limit)
         params = urllib.parse.urlencode(params)
         query_url = f'{search_url}/search/{query}&/?{params}'

--- a/test/test_partshop.py
+++ b/test/test_partshop.py
@@ -224,3 +224,34 @@ WHERE {
                                               doc.displayId, md.displayId,
                                               md.version)
         sbh.attachFile(md_uri, CRISPR_LOCATION)
+
+    def test_search_general(self):
+        sbh = sbol2.PartShop(TEST_RESOURCE)
+        # sbh.login(username, password)
+        results = sbh.search_general("NAND")
+        # The response is a list
+        self.assertEqual(list, type(results))
+        # There are 25 items in the list (search returns more,
+        # but by default we get the first 25)
+        self.assertEqual(25, len(results))
+        # The response items are all of type Identified
+        self.assertTrue(all([isinstance(x, sbol2.Identified)
+                             for x in results]))
+
+    # Exact search is not ready yet
+    @unittest.expectedFailure
+    def test_search_exact(self):
+        sbh = sbol2.PartShop(TEST_RESOURCE)
+        # sbh.login(username, password)
+        limit = 10
+        results = sbh.search_exact(sbol2.SO_CDS,
+                                   sbol2.SBOL_COMPONENT_DEFINITION,
+                                   sbol2.SBOL_ROLES,
+                                   limit=limit)
+        # The response is a list
+        self.assertEqual(list, type(results))
+        # The response contains _limit_ items
+        self.assertEqual(limit, len(results))
+        # The response items are all of type Identified
+        self.assertTrue(all([isinstance(x, sbol2.Identified)
+                             for x in results]))

--- a/test/test_partshop.py
+++ b/test/test_partshop.py
@@ -228,7 +228,7 @@ WHERE {
     def test_search_general(self):
         sbh = sbol2.PartShop(TEST_RESOURCE)
         # sbh.login(username, password)
-        results = sbh.search_general("NAND")
+        results = sbh.search("NAND")
         # The response is a list
         self.assertEqual(list, type(results))
         # There are 25 items in the list (search returns more,
@@ -238,16 +238,13 @@ WHERE {
         self.assertTrue(all([isinstance(x, sbol2.Identified)
                              for x in results]))
 
-    # Exact search is not ready yet
-    @unittest.expectedFailure
     def test_search_exact(self):
-        sbh = sbol2.PartShop(TEST_RESOURCE)
-        # sbh.login(username, password)
+        igem = sbol.PartShop('https://synbiohub.org')
         limit = 10
-        results = sbh.search_exact(sbol2.SO_CDS,
-                                   sbol2.SBOL_COMPONENT_DEFINITION,
-                                   sbol2.SBOL_ROLES,
-                                   limit=limit)
+        results = igem.search(sbol2.SO_PROMOTER,
+                              sbol2.SBOL_COMPONENT_DEFINITION,
+                              sbol2.SBOL_ROLES,
+                              0, limit)
         # The response is a list
         self.assertEqual(list, type(results))
         # The response contains _limit_ items
@@ -255,3 +252,8 @@ WHERE {
         # The response items are all of type Identified
         self.assertTrue(all([isinstance(x, sbol2.Identified)
                              for x in results]))
+        doc = sbol2.Document()
+        igem.pull([x.identity for x in results], doc, False)
+        self.assertEqual(10, len(doc))
+        for cd in doc.componentDefinitions:
+            self.assertIn(sbol2.SO_PROMOTER, cd.roles)

--- a/test/test_tutorial.py
+++ b/test/test_tutorial.py
@@ -3,6 +3,7 @@ import os
 import unittest
 
 import sbol2 as sbol
+import sbol2
 
 LOGGER_NAME = 'sbol2.test'
 DEBUG_ENV_VAR = 'SBOL_TEST_DEBUG'
@@ -58,8 +59,7 @@ class TestSbolTutorial(unittest.TestCase):
         self.assertEqual(len(list(doc.componentDefinitions)), 14)
         self.assertEqual(len(list(doc.moduleDefinitions)), 0)
 
-    @unittest.expectedFailure  # See Issue #25, PartShop has no attribute search
-    def test_partshop(self):
+    def get_device_from_synbiohub(self, doc):
         # Start an interface to igem's public part shop on
         # SynBioHub. Located at `https://synbiohub.org/public/igem`
         partshop = sbol.PartShop('https://synbiohub.org/public/igem')
@@ -70,4 +70,12 @@ class TestSbolTutorial(unittest.TestCase):
 
         # Import the medium strength device into your document
         medium_device_uri = records[0].identity
+        self.assertEqual(0, len(doc))
         partshop.pull(medium_device_uri, doc)
+        self.assertEqual(3, len(doc))
+
+    def test_tutorial(self):
+        doc = sbol2.Document()
+        # TODO: rename test_tutorial to get_device_from_xml
+        # self.get_device_from_xml(doc)
+        self.get_device_from_synbiohub(doc)


### PR DESCRIPTION
Enough of PartShop.search is now implemented to support the tutorial. Exact searching and
general searching are both supported. Advanced searching (#240) will come later.

Fixes #25 