### PR TITLE
Fix Document.copy argument order

### DIFF
--- a/sbol2/document.py
+++ b/sbol2/document.py
@@ -934,7 +934,7 @@ class Document(Identified):
         msg = msg.format(uri)
         raise SBOLError(msg, SBOLErrorCode.SBOL_ERROR_INVALID_ARGUMENT)
 
-    def copy(self, target_doc=None, target_namespace=None, version=None):
+    def copy(self, target_namespace=None, target_doc=None, version=None):
         # This enables the user to use the pattern doc2 = doc.copy() to clone a Document.
         # SWIG pySBOL assumes the user does NOT want to increment the Document's version
         # when creating a clone. (Whether or not these are the right semantics, that's

--- a/sbol2/identified.py
+++ b/sbol2/identified.py
@@ -344,10 +344,16 @@ def parseNamespace(uri):
 
 
 def replace_namespace(old_uri, target_namespace, rdf_type):
-    '''
+    """
     Utility function for mapping an SBOL object's identity into a new namespace. The
     rdf_type is used to map to and from sbol-typed namespaces.
-    '''
+    """
+
+    # Work around an issue where the Document itself is being copied and
+    # doesn't have its own URI, so old_uri is None. Return empty string
+    # because the identity is not allowed to be None.
+    if old_uri is None:
+        return ''
 
     # If the value is an SBOL-typed URI, replace both the namespace and class name
     class_name = parseClassName(rdf_type)

--- a/test/test_tutorial.py
+++ b/test/test_tutorial.py
@@ -24,8 +24,7 @@ class TestSbolTutorial(unittest.TestCase):
             self.logger.setLevel(logging.DEBUG)
             self.logger.debug('Debug logging enabled')
 
-    @unittest.expectedFailure  # See Issue 24, Document has no attribute copy
-    def test_tutorial(self):
+    def test_tutorial_part_1(self):
         # Set the default namespace (e.g. "http://my_namespace.org")
         namespace = "http://my_namespace.org"
         homespace = sbol.setHomespace(namespace)


### PR DESCRIPTION
Make Document.copy arguments backward compatible
with pySBOL. Remove expected failure from tutorial
unit test that now passes.

Fixes #174 