### PR TITLE
SBOLObject.getPropertyValue always returns a string

### DIFF
--- a/sbol2/location.py
+++ b/sbol2/location.py
@@ -102,7 +102,7 @@ class Range(Location):
 class Cut(Location):
     """The Cut class specifies a location between
     two coordinates of a Sequence's elements."""
-    def __init__(self, uri=URIRef('example'), at=1,
+    def __init__(self, uri=URIRef('example'), at=0,
                  *, type_uri=SBOL_CUT, version=VERSION_STRING):
         super().__init__(uri=uri, type_uri=type_uri, version=version)
         self._at = IntProperty(self, SBOL_AT, '1', '1', [], at)

--- a/sbol2/object.py
+++ b/sbol2/object.py
@@ -281,22 +281,28 @@ class SBOLObject:
         """Get the value of a custom annotation property by its URI.
 
         :param property_uri: The URI for the property.
-        :return: The value of the property or SBOL_ERROR_NOT_FOUND.
+        :type property_uri: str
+        :return: The value of the property.
+        :rtype: str
+        :raises: SBOLError(SBOL_ERROR_NOT_FOUND) if property does not exist
         """
         values = self.getPropertyValues(property_uri)
-        if not values:
+        try:
+            return str(values[0])
+        except IndexError:
             return ''
-        return str(values[0])
 
-    def getPropertyValues(self, property_uri: str) -> List:
+    def getPropertyValues(self, property_uri: str) -> List[str]:
         """Get all values of a custom annotation property by its URI.
 
         :param property_uri: The URI for the property.
-        :return: A vector of property values or SBOL_ERROR_NOT_FOUND.
+        :type property_uri: str
+        :return: A vector of property values.
+        :rtype: list of strings
+        :raises: SBOLError(SBOL_ERROR_NOT_FOUND) if property does not exist
         """
-        key = rdflib.URIRef(property_uri)
         try:
-            return self.properties[key]
+            return [str(x) for x in self.properties[property_uri]]
         except KeyError as e:
             # no property by this name
             raise SBOLError('Property {} not found'.format(property_uri),

--- a/sbol2/object.py
+++ b/sbol2/object.py
@@ -1,5 +1,6 @@
 import logging
 import posixpath
+from typing import List
 
 from deprecated import deprecated
 import rdflib
@@ -276,16 +277,18 @@ class SBOLObject:
             return False
         return True
 
-    def getPropertyValue(self, property_uri):
+    def getPropertyValue(self, property_uri: str) -> str:
         """Get the value of a custom annotation property by its URI.
 
         :param property_uri: The URI for the property.
         :return: The value of the property or SBOL_ERROR_NOT_FOUND.
         """
         values = self.getPropertyValues(property_uri)
-        return values[0]
+        if not values:
+            return ''
+        return str(values[0])
 
-    def getPropertyValues(self, property_uri):
+    def getPropertyValues(self, property_uri: str) -> List:
         """Get all values of a custom annotation property by its URI.
 
         :param property_uri: The URI for the property.

--- a/test/test_document.py
+++ b/test/test_document.py
@@ -367,9 +367,9 @@ class TestDocument(unittest.TestCase):
         info = cd.owned_objects[info_uri][0]
         self.assertIsNotNone(info)
         self.assertEqual(info.getPropertyValue(sigma_uri),
-                         rdflib.Literal('//rnap/prokaryote/ecoli/sigma70'))
+                         '//rnap/prokaryote/ecoli/sigma70')
         self.assertEqual(info.getPropertyValue(regulation_uri),
-                         rdflib.Literal('//regulation/constitutive'))
+                         '//regulation/constitutive')
 
     def test_recursive_add(self):
         # Make sure that when an object gets added to a document

--- a/test/test_object.py
+++ b/test/test_object.py
@@ -226,3 +226,18 @@ class TestObject(unittest.TestCase):
         # hashable test above can be fooled according to the
         # documentation.
         self.assertTrue(isinstance(hash(obj), int))
+
+    def test_get_property(self):
+        # If a property is unset, return an empty string instead of
+        # an IndexError
+        fc = sbol2.FunctionalComponent()
+        self.assertEqual('', fc.getPropertyValue(sbol2.SBOL_NAME))
+
+        # getPropertyValue always returns a string, even if the
+        # property is an IntProperty
+        c = sbol.Cut()
+        self.assertEqual('0', c.getPropertyValue(sbol.SBOL_AT))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes #255

pysbol's `SBOLObject.getPropertyValue` always returns a string from getPropertyValue. Do the same here. Update unit tests as needed to reflect this.