### PR TITLE
Change assertEquals to assertEqual

### DIFF
--- a/sbol2/sequence.py
+++ b/sbol2/sequence.py
@@ -6,6 +6,7 @@ from .property import LiteralProperty, URIProperty
 from .toplevel import TopLevel
 from .config import Config
 
+
 class Sequence(TopLevel):
     """
     The primary structure (eg, nucleotide or amino acid sequence)

--- a/test/test_componentdefinition.py
+++ b/test/test_componentdefinition.py
@@ -358,20 +358,20 @@ class TestAssemblyRoutines(unittest.TestCase):
         cd3.assemblePrimaryStructure([cd1, cd2])
         cd5.assemblePrimaryStructure([cd4, cd3])
         cd5.compile()
-        self.assertEquals(cd3.sequence.elements, 'ttgg')
-        self.assertEquals(cd5.sequence.elements, 'aattgg')
+        self.assertEqual(cd3.sequence.elements, 'ttgg')
+        self.assertEqual(cd5.sequence.elements, 'aattgg')
         r1 = cd3.sequenceAnnotations['cd1_annotation_0'].\
             locations['cd1_annotation_0_range']
         r2 = cd3.sequenceAnnotations['cd2_annotation_0'].\
             locations['cd2_annotation_0_range']
         r4 = cd5.sequenceAnnotations['cd4_annotation_0'].\
             locations['cd4_annotation_0_range']
-        self.assertEquals(r1.start, 3)
-        self.assertEquals(r1.end, 4)
-        self.assertEquals(r2.start, 5)
-        self.assertEquals(r2.end, 6)
-        self.assertEquals(r4.start, 1)
-        self.assertEquals(r4.end, 2)
+        self.assertEqual(r1.start, 3)
+        self.assertEqual(r1.end, 4)
+        self.assertEqual(r2.start, 5)
+        self.assertEqual(r2.end, 6)
+        self.assertEqual(r4.start, 1)
+        self.assertEqual(r4.end, 2)
 
     @unittest.expectedFailure
     def test_standard_assembly(self):
@@ -402,7 +402,7 @@ class TestAssemblyRoutines(unittest.TestCase):
                                       IGEM_STANDARD_ASSEMBLY)
         target_seq = gene.compile()
 
-        self.assertEquals(target_seq, 'atactagagttactagctactagagg')
+        self.assertEqual(target_seq, 'atactagagttactagctactagagg')
 
     def test_assemble_with_displayIds(self):
         sbol2.Config.setOption('sbol_typed_uris', True)


### PR DESCRIPTION
Stop using the deprecated `assertEquals` in unit tests.

Fixes #249 