### PR TITLE
Make all Property attributes transparent

### DIFF
--- a/sbol2/__init__.py
+++ b/sbol2/__init__.py
@@ -24,6 +24,7 @@ from .identified import Identified
 from .implementation import Implementation
 from .interaction import Interaction
 from .location import Location, Range, Cut, GenericLocation
+from .measurement import Measurement
 from .module import Module
 from .moduledefinition import ModuleDefinition
 from .object import SBOLObject

--- a/sbol2/attachment.py
+++ b/sbol2/attachment.py
@@ -11,15 +11,7 @@ class Attachment(TopLevel):
                  *, type_uri=SBOL_ATTACHMENT, version=VERSION_STRING,
                  source=''):
         super().__init__(type_uri, uri, version)
-        self._source = URIProperty(self, SBOL_SOURCE, '1', '1', [], source)
+        self.source = URIProperty(self, SBOL_SOURCE, '1', '1', [], source)
         self.format = LiteralProperty(self, SBOL_URI + '#format', '0', '1', [])
         self.size = LiteralProperty(self, SBOL_URI + '#size', '0', '1', [])
         self.hash = LiteralProperty(self, SBOL_URI + '#hash', '0', '1', [])
-
-    @property
-    def source(self):
-        return self._source.value
-
-    @source.setter
-    def source(self, new_source):
-        self._source.set(new_source)

--- a/sbol2/attachment.py
+++ b/sbol2/attachment.py
@@ -12,9 +12,9 @@ class Attachment(TopLevel):
                  source=''):
         super().__init__(type_uri, uri, version)
         self._source = URIProperty(self, SBOL_SOURCE, '1', '1', [], source)
-        self._format = LiteralProperty(self, SBOL_URI + '#format', '0', '1', [])
-        self._size = LiteralProperty(self, SBOL_URI + '#size', '0', '1', [])
-        self._hash = LiteralProperty(self, SBOL_URI + '#hash', '0', '1', [])
+        self.format = LiteralProperty(self, SBOL_URI + '#format', '0', '1', [])
+        self.size = LiteralProperty(self, SBOL_URI + '#size', '0', '1', [])
+        self.hash = LiteralProperty(self, SBOL_URI + '#hash', '0', '1', [])
 
     @property
     def source(self):
@@ -23,27 +23,3 @@ class Attachment(TopLevel):
     @source.setter
     def source(self, new_source):
         self._source.set(new_source)
-
-    @property
-    def format(self):
-        return self._format.value
-
-    @format.setter
-    def format(self, new_format):
-        self._format.set(new_format)
-
-    @property
-    def size(self):
-        return self._size.value
-
-    @size.setter
-    def size(self, new_size):
-        self._size.set(new_size)
-
-    @property
-    def hash(self):
-        return self._hash.value
-
-    @hash.setter
-    def hash(self, new_hash):
-        self._hash.set(new_hash)

--- a/sbol2/collection.py
+++ b/sbol2/collection.py
@@ -10,12 +10,4 @@ class Collection(TopLevel):
     def __init__(self, uri=URIRef("example"), version=VERSION_STRING,
                  *, type_uri=SBOL_COLLECTION):
         super().__init__(type_uri, uri, version)
-        self._members = URIProperty(self, SBOL_MEMBERS, '0', '*', [])
-
-    @property
-    def members(self):
-        return self._members.value
-
-    @members.setter
-    def members(self, new_members):
-        self._members.set(new_members)
+        self.members = URIProperty(self, SBOL_MEMBERS, '0', '*', [])

--- a/sbol2/combinatorialderivation.py
+++ b/sbol2/combinatorialderivation.py
@@ -12,7 +12,7 @@ class VariableComponent(Identified):
         super().__init__(type_uri, uri, version)
         self.variable = ReferencedObject(self, SBOL_VARIABLE,
                                          SBOL_COMPONENT, '0', '1', [])
-        self._repeat = URIProperty(self, SBOL_OPERATOR, '1', '1', [], repeat)
+        self.repeat = URIProperty(self, SBOL_OPERATOR, '1', '1', [], repeat)
         self.variants = ReferencedObject(self, SBOL_VARIANTS,
                                          SBOL_COMPONENT_DEFINITION,
                                          '0', '*', [])
@@ -25,14 +25,6 @@ class VariableComponent(Identified):
                                                    SBOL_COMBINATORIAL_DERIVATION,
                                                    '0', '*', [])
 
-    @property
-    def repeat(self):
-        return self._repeat.value
-
-    @repeat.setter
-    def repeat(self, new_repeat):
-        self._repeat.set(new_repeat)
-
 
 class CombinatorialDerivation(TopLevel):
 
@@ -42,18 +34,10 @@ class CombinatorialDerivation(TopLevel):
                  version=VERSION_STRING):
         super().__init__(type_uri, uri, version)
         # TODO in original source, it doesn't look like strategy is used
-        self._strategy = URIProperty(self, SBOL_STRATEGY, '1', '1', [])
+        self.strategy = URIProperty(self, SBOL_STRATEGY, '1', '1', [])
         self.masterTemplate = ReferencedObject(self, SBOL_TEMPLATE,
                                                SBOL_COMBINATORIAL_DERIVATION,
                                                '0', '1', [])
         self.variableComponents = OwnedObject(self, SBOL_VARIABLE_COMPONENTS,
                                               VariableComponent,
                                               '0', '*', [])
-
-    @property
-    def strategy(self):
-        return self._strategy.value
-
-    @strategy.setter
-    def strategy(self, new_strategy):
-        self._strategy.set(new_strategy)

--- a/sbol2/component.py
+++ b/sbol2/component.py
@@ -14,53 +14,33 @@ class ComponentInstance(Identified):
         self.definition = ReferencedObject(self, SBOL_DEFINITION,
                                            SBOL_COMPONENT_DEFINITION,
                                            '1', '1', [], definition)
-        self._access = URIProperty(self, SBOL_ACCESS, '0', '1', [], access)
+        self.access = URIProperty(self, SBOL_ACCESS, '0', '1', [], access)
         self.mapsTos = OwnedObject(self, SBOL_MAPS_TOS, MapsTo,
                                    '0', '*', [])
         self.measurements = OwnedObject(self, SBOL_MEASUREMENTS, Measurement,
                                         '0', '*', [])
-
-    @property
-    def access(self):
-        return self._access.value
-
-    @access.setter
-    def access(self, new_access):
-        self._access.set(new_access)
 
 
 class Component(ComponentInstance):
     def __init__(self, uri=URIRef('example'), definition='',
                  access=SBOL_ACCESS_PUBLIC, version=VERSION_STRING):
         super().__init__(SBOL_COMPONENT, uri, definition, access, version)
-        self._roles = URIProperty(self, SBOL_ROLES, '0', '*',
-                                  [Component._role_set_role_integration])
-        self._roleIntegration = URIProperty(self, SBOL_ROLE_INTEGRATION,
-                                            '0', '1', [])
+        self.roles = URIProperty(self, SBOL_ROLES, '0', '*',
+                                 [Component._role_set_role_integration])
+        self.roleIntegration = URIProperty(self, SBOL_ROLE_INTEGRATION,
+                                           '0', '1', [])
         self.sourceLocations = OwnedObject(self, SBOL_LOCATIONS, Location,
                                            '0', '*', [])
 
-    @property
-    def roles(self):
-        return self._roles.value
-
-    @roles.setter
-    def roles(self, new_roles):
-        self._roles.set(new_roles)
-
     def addRole(self, new_role):
-        self._roles.add(new_role)
+        val = self.roles
+        val.append(new_role)
+        self.roles = val
 
     def removeRole(self, index=0):
-        self._roles.remove(index)
-
-    @property
-    def roleIntegration(self):
-        return self._roleIntegration.value
-
-    @roleIntegration.setter
-    def roleIntegration(self, new_roleIntegration):
-        self._roleIntegration.set(new_roleIntegration)
+        val = self.roles
+        del val[index]
+        self.roles = val
 
     @staticmethod
     def _role_set_role_integration(sbol_obj, arg):
@@ -82,16 +62,8 @@ class FunctionalComponent(ComponentInstance):
                  version=VERSION_STRING):
         super().__init__(SBOL_FUNCTIONAL_COMPONENT, uri,
                          definition, access, version)
-        self._direction = URIProperty(self, SBOL_DIRECTION,
-                                      '1', '1', [], direction)
-
-    @property
-    def direction(self):
-        return self._direction.value
-
-    @direction.setter
-    def direction(self, new_direction):
-        self._direction.set(new_direction)
+        self.direction = URIProperty(self, SBOL_DIRECTION,
+                                     '1', '1', [], direction)
 
     def connect(self, interface_component):
         raise NotImplementedError("Not yet implemented")

--- a/sbol2/componentdefinition.py
+++ b/sbol2/componentdefinition.py
@@ -116,10 +116,10 @@ class ComponentDefinition(TopLevel):
         derived from this one
         """
         super().__init__(rdf_type, uri, version)
-        self._types = URIProperty(self, SBOL_TYPES,
-                                  '1', '*', None, component_type)
-        self._roles = URIProperty(self, SBOL_ROLES,
-                                  '0', '*', None)
+        self.types = URIProperty(self, SBOL_TYPES,
+                                 '1', '*', None, component_type)
+        self.roles = URIProperty(self, SBOL_ROLES,
+                                 '0', '*', None)
         self.sequence = OwnedObject(self, SBOL_SEQUENCE,
                                     Sequence,
                                     '0', '1', [libsbol_rule_20])
@@ -136,34 +136,25 @@ class ComponentDefinition(TopLevel):
                                                '0', '*', None)
         self._hidden_properties = [SBOL_SEQUENCE]
 
-    @property
-    def types(self):
-        return self._types.value
-
-    @types.setter
-    def types(self, new_types):
-        # perform validation prior to setting the value of the types property
-        self._types.set(new_types)
-
-    def addType(self, new_types):
-        self._types.add(new_types)
+    def addType(self, new_type):
+        val = self.types
+        val.append(new_type)
+        self.types = val
 
     def removeType(self, index=0):
-        self._types.remove(index)
-
-    @property
-    def roles(self):
-        return self._roles.value
-
-    @roles.setter
-    def roles(self, new_roles):
-        self._roles.set(new_roles)
+        val = self.types
+        del val[index]
+        self.types = val
 
     def addRole(self, new_role):
-        self._roles.add(new_role)
+        val = self.roles
+        val.append(new_role)
+        self.roles = val
 
     def removeRole(self, index=0):
-        self._roles.remove(index)
+        val = self.roles
+        del val[index]
+        self.roles = val
 
     def assemble(self, component_list, assembly_method=None, doc=None):
         """Assembles ComponentDefinitions into an abstraction hierarchy.

--- a/sbol2/document.py
+++ b/sbol2/document.py
@@ -161,10 +161,10 @@ class Document(Identified):
         self.experimentalData = OwnedObject(self, SBOL_EXPERIMENTAL_DATA,
                                             ExperimentalData,
                                             '0', '*', None)
-        self._citations = URIProperty(self, PURL_URI + "bibliographicCitation",
-                                      '0', '*', None)
-        self._keywords = URIProperty(self, PURL_URI + "elements/1.1/subject",
+        self.citations = URIProperty(self, PURL_URI + "bibliographicCitation",
                                      '0', '*', None)
+        self.keywords = URIProperty(self, PURL_URI + "elements/1.1/subject",
+                                    '0', '*', None)
         # I am my own document
         self.doc = self
         if filename is not None:
@@ -179,33 +179,25 @@ class Document(Identified):
             return False
         return True
 
-    @property
-    def citations(self):
-        return self._citations.value
-
-    @citations.setter
-    def citations(self, new_citations):
-        self._citations.set(new_citations)
-
     def addCitation(self, new_citation):
-        self._citations.add(new_citation)
+        val = self.citations
+        val.append(new_citation)
+        self.citations = val
 
     def removeCitation(self, index=0):
-        self._citations.remove(index)
-
-    @property
-    def keywords(self):
-        return self._keywords.value
-
-    @keywords.setter
-    def keywords(self, new_keywords):
-        self._keywords.set(new_keywords)
+        val = self.citations
+        del val[index]
+        self.citations = val
 
     def addKeyword(self, new_keyword):
-        self._keywords.add(new_keyword)
+        val = self.keywords
+        val.append(new_keyword)
+        self.keywords = val
 
     def removeKeyword(self, index=0):
-        self._keywords.remove(index)
+        val = self.keywords
+        del val[index]
+        self.keywords = val
 
     def add(self, sbol_obj):
         """

--- a/sbol2/identified.py
+++ b/sbol2/identified.py
@@ -87,13 +87,13 @@ class Identified(SBOLObject):
         super().__init__(type_uri, uri)
         self._persistentIdentity = URIProperty(self, SBOL_PERSISTENT_IDENTITY,
                                                '0', '1', None, URIRef(uri))
-        self._displayId = LiteralProperty(self, SBOL_DISPLAY_ID, '0', '1',
-                                          [validation.sbol_rule_10204])
-        self._version = LiteralProperty(self, SBOL_VERSION, '0', '1', None, version)
-        self._name = LiteralProperty(self, SBOL_NAME, '0', '1', None)
-        self._description = LiteralProperty(self, SBOL_DESCRIPTION, '0', '1', None)
+        self.displayId = LiteralProperty(self, SBOL_DISPLAY_ID, '0', '1',
+                                         [validation.sbol_rule_10204])
+        self.version = LiteralProperty(self, SBOL_VERSION, '0', '1', None, version)
+        self.name = LiteralProperty(self, SBOL_NAME, '0', '1', None)
+        self.description = LiteralProperty(self, SBOL_DESCRIPTION, '0', '1', None)
         if Config.getOption(ConfigOptions.SBOL_COMPLIANT_URIS.value) is True:
-            self._displayId.set(uri)
+            self.displayId = uri
             self._persistentIdentity.set(URIRef(posixpath.join(getHomespace(), uri)))
             if Config.getOption(ConfigOptions.SBOL_TYPED_URIS.value) is True:
                 if self.version:
@@ -133,38 +133,6 @@ class Identified(SBOLObject):
     @persistentIdentity.setter
     def persistentIdentity(self, new_persistentIdentity):
         self._persistentIdentity.set(new_persistentIdentity)
-
-    @property
-    def displayId(self):
-        return self._displayId.value
-
-    @displayId.setter
-    def displayId(self, new_displayId):
-        self._displayId.set(new_displayId)
-
-    @property
-    def version(self):
-        return self._version.value
-
-    @version.setter
-    def version(self, new_version):
-        self._version.set(new_version)
-
-    @property
-    def description(self):
-        return self._description.value
-
-    @description.setter
-    def description(self, new_description):
-        self._description.set(new_description)
-
-    @property
-    def name(self):
-        return self._name.value
-
-    @name.setter
-    def name(self, new_name):
-        self._name.set(new_name)
 
     @property
     def wasDerivedFrom(self):

--- a/sbol2/identified.py
+++ b/sbol2/identified.py
@@ -107,7 +107,7 @@ class Identified(SBOLObject):
             else:
                 if self.version:
                     self.identity = URIRef(posixpath.join(getHomespace(),
-                                                           uri, self.version))
+                                                          uri, self.version))
                 else:
                     self.identity = URIRef(posixpath.join(getHomespace(), uri))
         elif hasHomespace():

--- a/sbol2/identified.py
+++ b/sbol2/identified.py
@@ -85,8 +85,8 @@ class Identified(SBOLObject):
     def __init__(self, type_uri=SBOL_IDENTIFIED, uri=URIRef('example'),
                  version=VERSION_STRING):
         super().__init__(type_uri, uri)
-        self._persistentIdentity = URIProperty(self, SBOL_PERSISTENT_IDENTITY,
-                                               '0', '1', None, URIRef(uri))
+        self.persistentIdentity = URIProperty(self, SBOL_PERSISTENT_IDENTITY,
+                                              '0', '1', None, URIRef(uri))
         self.displayId = LiteralProperty(self, SBOL_DISPLAY_ID, '0', '1',
                                          [validation.sbol_rule_10204])
         self.version = LiteralProperty(self, SBOL_VERSION, '0', '1', None, version)
@@ -94,53 +94,32 @@ class Identified(SBOLObject):
         self.description = LiteralProperty(self, SBOL_DESCRIPTION, '0', '1', None)
         if Config.getOption(ConfigOptions.SBOL_COMPLIANT_URIS.value) is True:
             self.displayId = uri
-            self._persistentIdentity.set(URIRef(posixpath.join(getHomespace(), uri)))
+            self.persistentIdentity = URIRef(posixpath.join(getHomespace(), uri))
             if Config.getOption(ConfigOptions.SBOL_TYPED_URIS.value) is True:
                 if self.version:
-                    self._identity.set(
-                        URIRef(posixpath.join(getHomespace(),
-                                              self.getClassName(type_uri),
-                                              uri, self.version))
-                    )
+                    self.identity = URIRef(posixpath.join(getHomespace(),
+                                                          self.getClassName(type_uri),
+                                                          uri, self.version))
                 else:
-                    self._identity.set(
-                        URIRef(posixpath.join(getHomespace(),
-                                              self.getClassName(type_uri),
-                                              uri))
-                    )
+                    self.identity = URIRef(posixpath.join(getHomespace(),
+                                                          self.getClassName(type_uri),
+                                                          uri))
             else:
                 if self.version:
-                    self._identity.set(
-                        URIRef(posixpath.join(getHomespace(), uri, self.version)))
+                    self.identity = URIRef(posixpath.join(getHomespace(),
+                                                           uri, self.version))
                 else:
-                    self._identity.set(
-                        URIRef(posixpath.join(getHomespace(), uri)))
+                    self.identity = URIRef(posixpath.join(getHomespace(), uri))
         elif hasHomespace():
-            self._identity.set(URIRef(posixpath.join(getHomespace(), uri)))
-            self._persistentIdentity.set(
-                URIRef(posixpath.join(getHomespace(), uri)))
+            self.identity = URIRef(posixpath.join(getHomespace(), uri))
+            self.persistentIdentity = URIRef(posixpath.join(getHomespace(),
+                                                            uri))
         # Provo hooks
-        self._wasDerivedFrom = URIProperty(self, SBOL_WAS_DERIVED_FROM,
-                                           '0', '*', None)
+        self.wasDerivedFrom = URIProperty(self, SBOL_WAS_DERIVED_FROM,
+                                          '0', '*', None)
         self.wasGeneratedBy = ReferencedObject(self, PROVO_WAS_GENERATED_BY,
                                                PROVO_WAS_GENERATED_BY, '0', '*', [])
         # self._identity.validate() # TODO
-
-    @property
-    def persistentIdentity(self):
-        return self._persistentIdentity.value
-
-    @persistentIdentity.setter
-    def persistentIdentity(self, new_persistentIdentity):
-        self._persistentIdentity.set(new_persistentIdentity)
-
-    @property
-    def wasDerivedFrom(self):
-        return self._wasDerivedFrom.value
-
-    @wasDerivedFrom.setter
-    def wasDerivedFrom(self, new_wasDerivedFrom):
-        self._wasDerivedFrom.set(new_wasDerivedFrom)
 
     def generate(self):
         raise NotImplementedError("Not yet implemented")
@@ -164,8 +143,8 @@ class Identified(SBOLObject):
                 version = VERSION_STRING
             obj_id = posixpath.join(persistent_id, version)
             # Reset SBOLCompliant properties
-            self._identity.set(obj_id)
-            self._persistentIdentity.set(persistent_id)
+            self.identity = obj_id
+            self.persistentIdentity = persistent_id
             # Check for uniqueness of URI in local object properties
             matches = parent.find_property_value(SBOL_IDENTIFIED, obj_id)
             if len(matches) > 0:
@@ -214,15 +193,15 @@ class Identified(SBOLObject):
         if target_namespace:
 
             # Map the identity of self into the target namespace
-            if '_identity' in self.__dict__.keys():
-                old_uri = self.__dict__['_identity'].value
+            if hasattr(self, 'identity'):
+                old_uri = self.identity
                 new_uri = replace_namespace(old_uri, target_namespace, self.getTypeURI())
-                new_obj.__dict__['_identity'].value = new_uri
+                new_obj.identity = new_uri
 
-            if '_persistentIdentity' in self.__dict__.keys():
-                old_uri = self.__dict__['_persistentIdentity'].value
+            if hasattr(self, 'persistentIdentity'):
+                old_uri = self.persistentIdentity
                 new_uri = replace_namespace(old_uri, target_namespace, self.getTypeURI())
-                new_obj.__dict__['_persistentIdentity'].value = new_uri
+                new_obj.persistentIdentity = new_uri
 
             # Map any references to other SBOL objects in the Document into the new
             # namespace

--- a/sbol2/implementation.py
+++ b/sbol2/implementation.py
@@ -10,12 +10,4 @@ class Implementation(TopLevel):
     def __init__(self, uri=URIRef("example"), version=VERSION_STRING,
                  *, type_uri=SBOL_IMPLEMENTATION):
         super().__init__(type_uri, uri, version)
-        self._built = URIProperty(self, SBOL_URI+'#built', '0', '1', [])
-
-    @property
-    def built(self):
-        return self._built.value
-
-    @built.setter
-    def built(self, new_built):
-        self._built.set(new_built)
+        self.built = URIProperty(self, SBOL_URI+'#built', '0', '1', [])

--- a/sbol2/interaction.py
+++ b/sbol2/interaction.py
@@ -16,8 +16,8 @@ class Interaction(Identified):
                                                 SBOL_FUNCTIONAL_COMPONENTS,
                                                 FunctionalComponent,
                                                 '0', '*', [validation.libsbol_rule_18])
-        self._types = URIProperty(self, SBOL_TYPES,
-                                  '1', '*', [], interaction_type)
+        self.types = URIProperty(self, SBOL_TYPES,
+                                 '1', '*', [], interaction_type)
         self.participations = OwnedObject(self, SBOL_PARTICIPATIONS,
                                           Participation,
                                           '0', '*', [])
@@ -25,11 +25,3 @@ class Interaction(Identified):
                                         Measurement,
                                         '0', '*', [])
         # TODO hidden properties
-
-    @property
-    def types(self):
-        return self._types.value
-
-    @types.setter
-    def types(self, new_types):
-        self._types.set(new_types)

--- a/sbol2/location.py
+++ b/sbol2/location.py
@@ -13,18 +13,10 @@ class Location(Identified):
     def __init__(self, uri=URIRef('example'), orientation=SBOL_ORIENTATION_INLINE,
                  *, type_uri=SBOL_LOCATION, version=VERSION_STRING):
         super().__init__(type_uri=type_uri, uri=uri, version=version)
-        self._orientation = URIProperty(self, SBOL_ORIENTATION,
-                                        '1', '1', [], orientation)
+        self.orientation = URIProperty(self, SBOL_ORIENTATION,
+                                       '1', '1', [], orientation)
         self.sequence = ReferencedObject(self, SBOL_SEQUENCE_PROPERTY,
                                          SBOL_SEQUENCE, '0', '1', [])
-
-    @property
-    def orientation(self):
-        return self._orientation.value
-
-    @orientation.setter
-    def orientation(self, new_orientation):
-        self._orientation.set(new_orientation)
 
 
 class Range(Location):

--- a/sbol2/location.py
+++ b/sbol2/location.py
@@ -37,24 +37,8 @@ class Range(Location):
     def __init__(self, uri=URIRef('example'), start=1, end=2,
                  *, type_uri=SBOL_RANGE, version=VERSION_STRING):
         super().__init__(uri=uri, type_uri=type_uri, version=version)
-        self._start = IntProperty(self, SBOL_START, '0', '1', None, start)
-        self._end = IntProperty(self, SBOL_END, '0', '1', None, end)
-
-    @property
-    def start(self):
-        return self._start.value
-
-    @start.setter
-    def start(self, val):
-        self._start.set(val)
-
-    @property
-    def end(self):
-        return self._end.value
-
-    @end.setter
-    def end(self, val):
-        self._end.set(val)
+        self.start = IntProperty(self, SBOL_START, '0', '1', None, start)
+        self.end = IntProperty(self, SBOL_END, '0', '1', None, end)
 
     def precedes(self, comparand):
         if self.end < comparand.start:
@@ -105,15 +89,7 @@ class Cut(Location):
     def __init__(self, uri=URIRef('example'), at=0,
                  *, type_uri=SBOL_CUT, version=VERSION_STRING):
         super().__init__(uri=uri, type_uri=type_uri, version=version)
-        self._at = IntProperty(self, SBOL_AT, '1', '1', [], at)
-
-    @property
-    def at(self):
-        return self._at.value
-
-    @at.setter
-    def at(self, new_at):
-        self._at.set(new_at)
+        self.at = IntProperty(self, SBOL_AT, '1', '1', [], at)
 
 
 class GenericLocation(Location):

--- a/sbol2/mapsto.py
+++ b/sbol2/mapsto.py
@@ -14,13 +14,5 @@ class MapsTo(Identified):
                                       '1', '1', [], local)
         self.remote = ReferencedObject(self, SBOL_REMOTE, SBOL_COMPONENT,
                                        '1', '1', [], remote)
-        self._refinement = URIProperty(self, SBOL_REFINEMENT,
-                                       '1', '1', [], refinement)
-
-    @property
-    def refinement(self):
-        return self._refinement.value
-
-    @refinement.setter
-    def refinement(self, new_refinement):
-        self._refinement.set(new_refinement)
+        self.refinement = URIProperty(self, SBOL_REFINEMENT,
+                                      '1', '1', [], refinement)

--- a/sbol2/measurement.py
+++ b/sbol2/measurement.py
@@ -13,27 +13,15 @@ class Measurement(Identified):
                  unit='', version=VERSION_STRING):
         super().__init__(SBOL_MEASURE, uri, version)
         self.value = LiteralProperty(self, SBOL_VALUE, '1', '1', [], value)
-        self._unit = URIProperty(self, SBOL_UNIT, '1', '1', [], unit)
-        self._types = URIProperty(self, SBOL_TYPES, '0', '*', [])
-
-    @property
-    def unit(self):
-        return self._unit.value
-
-    @unit.setter
-    def unit(self, new_unit):
-        self._unit.set(new_unit)
-
-    @property
-    def types(self):
-        return self._types.value
-
-    @types.setter
-    def types(self, new_types):
-        self._types.set(new_types)
+        self.unit = URIProperty(self, SBOL_UNIT, '1', '1', [], unit)
+        self.types = URIProperty(self, SBOL_TYPES, '0', '*', [])
 
     def addType(self, new_type):
-        self._types.add(new_type)
+        val = self.types
+        val.append(new_type)
+        self.types = val
 
     def removeType(self, index=0):
-        self._types.remove(index)
+        val = self.types
+        del val[index]
+        self.types = val

--- a/sbol2/measurement.py
+++ b/sbol2/measurement.py
@@ -9,7 +9,7 @@ class Measurement(Identified):
     """The purpose of the Measure class is to link a numerical value
     to a unit of measure."""
 
-    def __init__(self, uri=URIRef('example'), value=0.0,
+    def __init__(self, uri=URIRef('example'), value='0.0',
                  unit='', version=VERSION_STRING):
         super().__init__(SBOL_MEASURE, uri, version)
         self.value = LiteralProperty(self, SBOL_VALUE, '1', '1', [], value)

--- a/sbol2/measurement.py
+++ b/sbol2/measurement.py
@@ -12,17 +12,9 @@ class Measurement(Identified):
     def __init__(self, uri=URIRef('example'), value=0.0,
                  unit='', version=VERSION_STRING):
         super().__init__(SBOL_MEASURE, uri, version)
-        self._value = LiteralProperty(self, SBOL_VALUE, '1', '1', [], value)
+        self.value = LiteralProperty(self, SBOL_VALUE, '1', '1', [], value)
         self._unit = URIProperty(self, SBOL_UNIT, '1', '1', [], unit)
         self._types = URIProperty(self, SBOL_TYPES, '0', '*', [])
-
-    @property
-    def value(self):
-        return self._value.value
-
-    @value.setter
-    def value(self, new_value):
-        self._value.set(new_value)
 
     @property
     def unit(self):

--- a/sbol2/model.py
+++ b/sbol2/model.py
@@ -10,33 +10,9 @@ class Model(TopLevel):
                  language=EDAM_SBML, framework=SBO_CONTINUOUS,
                  version=VERSION_STRING):
         super().__init__(rdf_type, uri, version)
-        self._source = URIProperty(self, SBOL_SOURCE,
-                                   '0', '1', [], source)
-        self._language = URIProperty(self, SBOL_LANGUAGE,
-                                     '0', '1', [], language)
-        self._framework = URIProperty(self, SBOL_FRAMEWORK,
-                                      '0', '1', [], framework)
-
-    @property
-    def source(self):
-        return self._source.value
-
-    @source.setter
-    def source(self, new_source):
-        self._source.set(new_source)
-
-    @property
-    def language(self):
-        return self._language.value
-
-    @language.setter
-    def language(self, new_language):
-        self._language.set(new_language)
-
-    @property
-    def framework(self):
-        return self._framework.value
-
-    @framework.setter
-    def framework(self, new_framework):
-        self._framework.set(new_framework)
+        self.source = URIProperty(self, SBOL_SOURCE,
+                                  '0', '1', [], source)
+        self.language = URIProperty(self, SBOL_LANGUAGE,
+                                    '0', '1', [], language)
+        self.framework = URIProperty(self, SBOL_FRAMEWORK,
+                                     '0', '1', [], framework)

--- a/sbol2/moduledefinition.py
+++ b/sbol2/moduledefinition.py
@@ -91,7 +91,7 @@ class ModuleDefinition(TopLevel):
         derived from this one (optional)
         """
         super().__init__(sbol_type_uri, uri, version)
-        self._roles = URIProperty(self, SBOL_ROLES, '0', '*', None)
+        self.roles = URIProperty(self, SBOL_ROLES, '0', '*', None)
         self.models = ReferencedObject(self, SBOL_MODELS,
                                        SBOL_MODEL, '0', '*', [])
         self.functionalComponents = OwnedObject(self,
@@ -104,19 +104,15 @@ class ModuleDefinition(TopLevel):
                                         Interaction,
                                         '0', '*', [validation.libsbol_rule_17])
 
-    @property
-    def roles(self):
-        return self._roles.value
-
-    @roles.setter
-    def roles(self, new_roles):
-        self._roles.set(new_roles)
-
     def addRole(self, new_role):
-        self._roles.add(new_role)
+        val = self.roles
+        val.append(new_role)
+        self.roles = val
 
     def removeRole(self, index=0):
-        self._roles.remove(index)
+        val = self.roles
+        del val[index]
+        self.roles = val
 
     def setOutput(self, output):
         """Defines an output for a sub-Module.

--- a/sbol2/object.py
+++ b/sbol2/object.py
@@ -9,9 +9,7 @@ from rdflib import URIRef
 from .config import getHomespace, string_equal
 from .config import hasHomespace
 from .constants import *
-from .property import LiteralProperty, OwnedObject
-from .property import ReferencedObject
-from .property import URIProperty
+from .property import LiteralProperty, OwnedObject, URIProperty
 from .sbolerror import SBOLError
 from .sbolerror import SBOLErrorCode
 from .uridict import URIDict

--- a/sbol2/object.py
+++ b/sbol2/object.py
@@ -9,7 +9,7 @@ from rdflib import URIRef
 from .config import getHomespace, string_equal
 from .config import hasHomespace
 from .constants import *
-from .property import OwnedObject
+from .property import IntProperty, OwnedObject
 from .property import ReferencedObject
 from .property import URIProperty
 from .sbolerror import SBOLError
@@ -483,6 +483,8 @@ class SBOLObject:
                     result = None
             else:
                 result = sbol_property
+        elif isinstance(result, IntProperty):
+            result = result.value
         return result
 
     def _is_owned_object(self, name):
@@ -491,21 +493,22 @@ class SBOLObject:
         except KeyError:
             return False
 
-    def _is_referenced_object(self, name):
+    def _is_transparent_attribute(self, name):
         try:
-            return isinstance(self.__dict__[name], ReferencedObject)
+            attr = self.__dict__[name]
         except KeyError:
             return False
+        return isinstance(attr, (IntProperty, ReferencedObject))
 
-    def _set_referenced_object(self, name, value):
+    def _set_transparent_attribute(self, name, value):
         self.__dict__[name].set(value)
 
     def _set_owned_object(self, name, value):
         self.__dict__[name].set(value)
 
     def __setattr__(self, name, value):
-        if self._is_referenced_object(name):
-            self._set_referenced_object(name, value)
+        if self._is_transparent_attribute(name):
+            self._set_transparent_attribute(name, value)
             return
         if self._is_owned_object(name):
             self._set_owned_object(name, value)

--- a/sbol2/object.py
+++ b/sbol2/object.py
@@ -101,8 +101,8 @@ class SBOLObject:
         self._hidden_properties = []
         self.rdf_type = str(_rdf_type)
         self._namespaces = {}
-        self._identity = URIProperty(self, SBOL_IDENTITY, '0', '1',
-                                     [validation.sbol_rule_10202])
+        self.identity = URIProperty(self, SBOL_IDENTITY, '0', '1',
+                                    [validation.sbol_rule_10202])
         uri = URIRef(uri)
         if hasHomespace():
             uri = posixpath.join(getHomespace(), uri)
@@ -120,15 +120,6 @@ class SBOLObject:
 
     def __uri__(self):
         return self.identity
-
-    @property
-    def identity(self):
-        # Return the value associated with the identity property
-        return self._identity.value
-
-    @identity.setter
-    def identity(self, new_identity):
-        self._identity.value = new_identity
 
     @property
     def type(self):
@@ -479,7 +470,7 @@ class SBOLObject:
                     result = None
             else:
                 result = sbol_property
-        elif isinstance(result, (LiteralProperty, ReferencedObject)):
+        elif isinstance(result, (LiteralProperty, URIProperty)):
             # Convert these as appropriate so the Property attributes are
             # transparent and look like native types.
             result = result.value
@@ -496,7 +487,7 @@ class SBOLObject:
             attr = self.__dict__[name]
         except KeyError:
             return False
-        return isinstance(attr, (LiteralProperty, ReferencedObject))
+        return isinstance(attr, (LiteralProperty, URIProperty))
 
     def _set_transparent_attribute(self, name, value):
         self.__dict__[name].set(value)

--- a/sbol2/object.py
+++ b/sbol2/object.py
@@ -9,7 +9,7 @@ from rdflib import URIRef
 from .config import getHomespace, string_equal
 from .config import hasHomespace
 from .constants import *
-from .property import LiteralProperty, OwnedObject, URIProperty
+from .property import Property, OwnedObject, URIProperty
 from .sbolerror import SBOLError
 from .sbolerror import SBOLErrorCode
 from .uridict import URIDict
@@ -417,7 +417,7 @@ class SBOLObject:
                 owned_obj.build_graph(graph)
 
     def __str__(self):
-        return str(self.identity)
+        return self.identity
 
     def is_top_level(self):
         return False
@@ -434,36 +434,25 @@ class SBOLObject:
                     result = None
             else:
                 result = sbol_property
-        elif isinstance(result, (LiteralProperty, URIProperty)):
-            # Convert these as appropriate so the Property attributes are
+        elif isinstance(result, Property):
+            # Else if attribute is any other kind of Property besides
+            # OwnedObject, convert so the Property attributes are
             # transparent and look like native types.
             result = result.value
         return result
-
-    def _is_owned_object(self, name):
-        try:
-            return isinstance(self.__dict__[name], OwnedObject)
-        except KeyError:
-            return False
 
     def _is_transparent_attribute(self, name):
         try:
             attr = self.__dict__[name]
         except KeyError:
             return False
-        return isinstance(attr, (LiteralProperty, URIProperty))
+        return isinstance(attr, Property)
 
     def _set_transparent_attribute(self, name, value):
-        self.__dict__[name].set(value)
-
-    def _set_owned_object(self, name, value):
         self.__dict__[name].set(value)
 
     def __setattr__(self, name, value):
         if self._is_transparent_attribute(name):
             self._set_transparent_attribute(name, value)
-            return
-        if self._is_owned_object(name):
-            self._set_owned_object(name, value)
             return
         object.__setattr__(self, name, value)

--- a/sbol2/object.py
+++ b/sbol2/object.py
@@ -9,7 +9,7 @@ from rdflib import URIRef
 from .config import getHomespace, string_equal
 from .config import hasHomespace
 from .constants import *
-from .property import IntProperty, OwnedObject
+from .property import LiteralProperty, OwnedObject
 from .property import ReferencedObject
 from .property import URIProperty
 from .sbolerror import SBOLError
@@ -470,11 +470,7 @@ class SBOLObject:
     def __getattribute__(self, name):
         # Call the default method
         result = object.__getattribute__(self, name)
-        if isinstance(result, ReferencedObject):
-            # Convert the ReferencedObject to a value instead of
-            # returning the ReferencedObject itself
-            result = result.value
-        elif isinstance(result, OwnedObject):
+        if isinstance(result, OwnedObject):
             sbol_property = object.__getattribute__(self, name)
             if sbol_property.upper_bound == 1:
                 if len(sbol_property):
@@ -483,7 +479,9 @@ class SBOLObject:
                     result = None
             else:
                 result = sbol_property
-        elif isinstance(result, IntProperty):
+        elif isinstance(result, (LiteralProperty, ReferencedObject)):
+            # Convert these as appropriate so the Property attributes are
+            # transparent and look like native types.
             result = result.value
         return result
 
@@ -498,7 +496,7 @@ class SBOLObject:
             attr = self.__dict__[name]
         except KeyError:
             return False
-        return isinstance(attr, (IntProperty, ReferencedObject))
+        return isinstance(attr, (LiteralProperty, ReferencedObject))
 
     def _set_transparent_attribute(self, name, value):
         self.__dict__[name].set(value)

--- a/sbol2/object.py
+++ b/sbol2/object.py
@@ -416,40 +416,6 @@ class SBOLObject:
                            URIRef(owned_obj.identity)))
                 owned_obj.build_graph(graph)
 
-    def serialize_rdf2xml(self, graph):
-        """Serialize the SBOLObject.
-
-        :param os: Output stream.
-        :param indentLevel:
-        :return: None
-        """
-        # Serialize properties
-        for rdf_type, vals in self.properties.items():
-            if rdf_type == 'http://sbols.org/v2#identity':
-                # This property is not serialized
-                continue
-            if len(vals) == 0:
-                #  No properties of this type
-                continue
-            predicate = self.doc.referenceNamespace(rdf_type)
-            for val in vals:
-                graph.add((self._identity.getRawValue(), predicate, val))
-        # Serialize owned objects
-        for name, object_store in self.owned_objects:
-            if len(object_store) == 0:
-                continue
-            # predicate = self.doc.referenceNamespace(name)
-            for obj in object_store:
-                # NOTE: couldn't we just use 'name'? (Would probably work the same,
-                # but wanted to follow the original implementation as closely as
-                # possible.)
-                typeURI = obj.getTypeURI()
-                if typeURI in self._hidden_properties:
-                    continue
-                rdfType = self.doc.referenceNamespace(typeURI)
-                graph.add((self._identity.getRawValue(), rdfType, obj.identity))
-                obj.serialize_rdf2xml(graph)  # recursive
-
     def __str__(self):
         return str(self.identity)
 

--- a/sbol2/participation.py
+++ b/sbol2/participation.py
@@ -11,26 +11,22 @@ class Participation(Identified):
     def __init__(self, type_uri=SBOL_PARTICIPATION, uri=URIRef('example'),
                  participant='', version=VERSION_STRING):
         super().__init__(type_uri, uri, version)
-        self._roles = URIProperty(self, SBOL_ROLES, '0', '*', [])
+        self.roles = URIProperty(self, SBOL_ROLES, '0', '*', [])
         self.participant = ReferencedObject(self, SBOL_PARTICIPANT,
                                             SBOL_FUNCTIONAL_COMPONENT,
                                             '1', '1', [], participant)
         self.measurements = OwnedObject(self, SBOL_MEASUREMENTS,
                                         Measurement, '0', '*', [])
 
-    @property
-    def roles(self):
-        return self._roles.value
-
-    @roles.setter
-    def roles(self, new_roles):
-        self._roles.set(new_roles)
-
     def addRole(self, new_role):
-        self._roles.add(new_role)
+        val = self.roles
+        val.append(new_role)
+        self.roles = val
 
     def removeRole(self, index=0):
-        self._roles.remove(index)
+        val = self.roles
+        del val[index]
+        self.roles = val
 
     def define(self, species, role=""):
         raise NotImplementedError('Not yet implemented')

--- a/sbol2/property.py
+++ b/sbol2/property.py
@@ -228,7 +228,8 @@ class Property(ABC):
         """In pysbol there are 4 constructors for each Property. We have
         to figure out which constructor the user intended to call based on
         the arguments. The signatures are:
-            IntProperty(owner, rdf_type, low_bound, high_bound, ValidationRules, initial_value)
+            IntProperty(owner, rdf_type, low_bound, high_bound, ValidationRules,
+                        initial_value)
             IntProperty(owner, rdf_type, low_bound, high_bound, ValidationRules)
             IntProperty(owner, rdf_type, low_bound, high_bound, initial_value)
             IntProperty(owner, rdf_type, low_bound, high_bound)

--- a/sbol2/provo.py
+++ b/sbol2/provo.py
@@ -22,8 +22,8 @@ class Association(Identified):
     # The plan property is OPTIONAL and contains a URI that refers to a Plan.
     plan = None
 
-    def __init__(self, uri=URIRef("example"), agent=URIRef(""),
-                 role=URIRef(""), version=VERSION_STRING,
+    def __init__(self, uri=URIRef("example"), agent=None,
+                 role=None, version=VERSION_STRING,
                  rdf_type=PROVO_ASSOCIATION):
         """Constructor.
 
@@ -69,8 +69,8 @@ class Usage(Identified):
     # the usage of an entity referenced by the entity property.
     _roles = None
 
-    def __init__(self, uri=URIRef("example"), entity=URIRef(""),
-                 role=URIRef(""), version=VERSION_STRING,
+    def __init__(self, uri=URIRef("example"), entity=None,
+                 role=None, version=VERSION_STRING,
                  rdf_type=PROVO_USAGE):
         """Constructor.
 

--- a/sbol2/provo.py
+++ b/sbol2/provo.py
@@ -40,23 +40,19 @@ class Association(Identified):
         super().__init__(rdf_type, uri, version)
         self.agent = ReferencedObject(self, PROVO_AGENT_PROPERTY, PROVO_AGENT,
                                       '1', '1', [], agent)
-        self._roles = URIProperty(self, PROVO_HAD_ROLE, '1', '*', [], role)
+        self.roles = URIProperty(self, PROVO_HAD_ROLE, '1', '*', [], role)
         self.plan = ReferencedObject(self, PROVO_HAD_PLAN, PROVO_PLAN,
                                      '0', '1', [])
 
-    @property
-    def roles(self):
-        return self._roles.value
-
-    @roles.setter
-    def roles(self, new_roles):
-        self._roles.set(new_roles)
-
     def addRole(self, new_role):
-        self._roles.add(new_role)
+        val = self.roles
+        val.append(new_role)
+        self.roles = val
 
     def removeRole(self, index=0):
-        self._roles.remove(index)
+        val = self.roles
+        del val[index]
+        self.roles = val
 
 
 class Usage(Identified):
@@ -84,30 +80,18 @@ class Usage(Identified):
         :param type: The RDF type for an extension class derived from this one.
         """
         super().__init__(rdf_type, uri, version)
-        self._entity = URIProperty(self, PROVO_ENTITY, '1', '1', [], entity)
-        self._roles = URIProperty(self, PROVO_HAD_ROLE, '1', '*', [], role)
-
-    @property
-    def entity(self):
-        return self._entity.value
-
-    @entity.setter
-    def entity(self, new_entity):
-        self._entity.set(new_entity)
-
-    @property
-    def roles(self):
-        return self._roles.value
-
-    @roles.setter
-    def roles(self, new_roles):
-        self._roles.set(new_roles)
+        self.entity = URIProperty(self, PROVO_ENTITY, '1', '1', [], entity)
+        self.roles = URIProperty(self, PROVO_HAD_ROLE, '1', '*', [], role)
 
     def addRole(self, new_role):
-        self._roles.add(new_role)
+        val = self.roles
+        val.append(new_role)
+        self.roles = val
 
     def removeRole(self, index=0):
-        self._roles.remove(index)
+        val = self.roles
+        del val[index]
+        self.roles = val
 
 
 class Agent(TopLevel):
@@ -201,7 +185,7 @@ class Activity(TopLevel):
                                 '0', '1', [validation.libsbol_rule_22])
         self.agent = ReferencedObject(self, PROVO_AGENT, Agent,
                                       '0', '1', [validation.libsbol_rule_22])
-        self._types = URIProperty(self, SBOL_TYPES, '0', '1', [])
+        self.types = URIProperty(self, SBOL_TYPES, '0', '1', [])
         self.startedAtTime = LiteralProperty(self, PROVO_STARTED_AT_TIME,
                                              '0', '1', [])
         self.endedAtTime = LiteralProperty(self, PROVO_ENDED_AT_TIME,
@@ -212,11 +196,3 @@ class Activity(TopLevel):
                                   '0', '*', [])
         self.associations = OwnedObject(self, PROVO_QUALIFIED_ASSOCIATION,
                                         Association, '0', '*', [])
-
-    @property
-    def types(self):
-        return self._types.value
-
-    @types.setter
-    def types(self, new_types):
-        self._types.set(new_types)

--- a/sbol2/provo.py
+++ b/sbol2/provo.py
@@ -202,10 +202,10 @@ class Activity(TopLevel):
         self.agent = ReferencedObject(self, PROVO_AGENT, Agent,
                                       '0', '1', [validation.libsbol_rule_22])
         self._types = URIProperty(self, SBOL_TYPES, '0', '1', [])
-        self._startedAtTime = LiteralProperty(self, PROVO_STARTED_AT_TIME,
-                                              '0', '1', [])
-        self._endedAtTime = LiteralProperty(self, PROVO_ENDED_AT_TIME,
-                                            '0', '1', [])
+        self.startedAtTime = LiteralProperty(self, PROVO_STARTED_AT_TIME,
+                                             '0', '1', [])
+        self.endedAtTime = LiteralProperty(self, PROVO_ENDED_AT_TIME,
+                                           '0', '1', [])
         self.wasInformedBy = ReferencedObject(self, PROVO_WAS_INFORMED_BY,
                                               PROVO_ACTIVITY, '0', '*', [])
         self.usages = OwnedObject(self, PROVO_QUALIFIED_USAGE, Usage,
@@ -220,19 +220,3 @@ class Activity(TopLevel):
     @types.setter
     def types(self, new_types):
         self._types.set(new_types)
-
-    @property
-    def startedAtTime(self):
-        return self._startedAtTime.value
-
-    @startedAtTime.setter
-    def startedAtTime(self, new_startedAtTime):
-        self._startedAtTime.set(new_startedAtTime)
-
-    @property
-    def endedAtTime(self):
-        return self._endedAtTime.value
-
-    @endedAtTime.setter
-    def endedAtTime(self, new_endedAtTime):
-        self._endedAtTime.set(new_endedAtTime)

--- a/sbol2/sequence.py
+++ b/sbol2/sequence.py
@@ -40,8 +40,8 @@ class Sequence(TopLevel):
         # or the atoms and chemical bonds of a small molecule.
         self.elements = LiteralProperty(self, SBOL_ELEMENTS,
                                         '1', '1', [], elements)
-        self._encoding = URIProperty(self, SBOL_ENCODING,
-                                     '1', '1', [], encoding)
+        self.encoding = URIProperty(self, SBOL_ENCODING,
+                                    '1', '1', [], encoding)
 
     # The encoding property is REQUIRED and has a data type of URI.
     # This property MUST indicate how the elements property of a Sequence
@@ -64,13 +64,6 @@ class Sequence(TopLevel):
     # | DNA, RNA                  | IUPAC DNA, RNA | SBOL_ENCODING_IUPAC         | http://www.chem.qmul.ac.uk/iubmb/misc/naseq.html |
     # | Protein                   | IUPAC Protein  | SBOL_ENCODING_IUPAC_PROTEIN | http://www.chem.qmul.ac.uk/iupac/AminoAcid/      |
     # | Small Molecule            | SMILES         | SBOL_ENCODING_SMILES        | http://www.opensmiles.org/opensmiles.html        |
-    @property
-    def encoding(self):
-        return self._encoding.value
-
-    @encoding.setter
-    def encoding(self, new_encoding):
-        self._encoding.value = new_encoding
 
     def assemble(self, composite_sequence=""):
         """Calculates the complete sequence of a high-level Component

--- a/sbol2/sequence.py
+++ b/sbol2/sequence.py
@@ -32,23 +32,16 @@ class Sequence(TopLevel):
         from this one.
         """
         super().__init__(type_uri, uri, version)
-        self._elements = LiteralProperty(self, SBOL_ELEMENTS,
-                                         '1', '1', [], elements)
+
+        # The elements property is a REQUIRED String of characters that represents
+        # the constituents of a biological or chemical molecule. For example,
+        # these characters could represent the nucleotide bases
+        # of a molecule of DNA, the amino acid residues of a protein,
+        # or the atoms and chemical bonds of a small molecule.
+        self.elements = LiteralProperty(self, SBOL_ELEMENTS,
+                                        '1', '1', [], elements)
         self._encoding = URIProperty(self, SBOL_ENCODING,
                                      '1', '1', [], encoding)
-
-    # The elements property is a REQUIRED String of characters that represents
-    # the constituents of a biological or chemical molecule. For example,
-    # these characters could represent the nucleotide bases
-    # of a molecule of DNA, the amino acid residues of a protein,
-    # or the atoms and chemical bonds of a small molecule.
-    @property
-    def elements(self):
-        return str(self._elements.value)
-
-    @elements.setter
-    def elements(self, new_elements):
-        self._elements.value = new_elements
 
     # The encoding property is REQUIRED and has a data type of URI.
     # This property MUST indicate how the elements property of a Sequence

--- a/sbol2/sequenceannotation.py
+++ b/sbol2/sequenceannotation.py
@@ -20,21 +20,17 @@ class SequenceAnnotation(Identified):
         self.component = None  # TODO support ReferencedObject
         self.locations = OwnedLocation(self, SBOL_LOCATIONS,
                                        '0', '*', [])
-        self._roles = URIProperty(self, SBOL_ROLES, '0', '*', [])
-
-    @property
-    def roles(self):
-        return self._roles.value
-
-    @roles.setter
-    def roles(self, new_roles):
-        self._roles.set(new_roles)
+        self.roles = URIProperty(self, SBOL_ROLES, '0', '*', [])
 
     def addRole(self, new_role):
-        self._roles.add(new_role)
+        val = self.roles
+        val.append(new_role)
+        self.roles = val
 
     def removeRole(self, index=0):
-        self._roles.remove(index)
+        val = self.roles
+        del val[index]
+        self.roles = val
 
     def precedes(self, comparand):
         """Tests if the comparand SequenceAnnotation precedes this one

--- a/sbol2/sequenceconstraint.py
+++ b/sbol2/sequenceconstraint.py
@@ -15,13 +15,5 @@ class SequenceConstraint(Identified):
                                         '1', '1', [], subject)
         self.object = ReferencedObject(self, SBOL_OBJECT, SBOL_COMPONENT,
                                        '1', '1', [], obj)
-        self._restriction = URIProperty(self, SBOL_RESTRICTION,
-                                        '1', '1', [], restriction)
-
-    @property
-    def restriction(self):
-        return self._restriction.value
-
-    @restriction.setter
-    def restriction(self, new_restriction):
-        self._restriction.set(new_restriction)
+        self.restriction = URIProperty(self, SBOL_RESTRICTION,
+                                       '1', '1', [], restriction)

--- a/sbol2/toplevel.py
+++ b/sbol2/toplevel.py
@@ -20,10 +20,9 @@ class TopLevel(Identified):
         # TODO could this be moved into 'identified' constructor?
         if Config.getOption(ConfigOptions.SBOL_COMPLIANT_URIS.value) is True:
             if Config.getOption(ConfigOptions.SBOL_TYPED_URIS.value) is True:
-                self._persistentIdentity.set(
-                    posixpath.join(getHomespace(),
-                                   self.getClassName(type_uri),
-                                   self.displayId))
+                self.persistentIdentity = posixpath.join(getHomespace(),
+                                                         self.getClassName(type_uri),
+                                                         self.displayId)
         self.attachments = ReferencedObject(self, SBOL_ATTACHMENTS,
                                             SBOL_ATTACHMENT, '0', '*', [], [])
 

--- a/test/test_component.py
+++ b/test/test_component.py
@@ -23,6 +23,18 @@ class TestComponent(unittest.TestCase):
         self.assertEqual(sbol2.SBOL_ROLE_INTEGRATION_OVERRIDE,
                          c.roleIntegration)
 
+    def test_add_remove_role(self):
+        c = sbol2.Component('c1')
+        self.assertEqual([], c.roles)
+        c.addRole(sbol2.SO_PROMOTER)
+        self.assertEqual([sbol2.SO_PROMOTER], c.roles)
+        c.addRole(sbol2.SO_MISC)
+        self.assertEqual([sbol2.SO_PROMOTER, sbol2.SO_MISC], c.roles)
+        c.addRole(sbol2.SO_CDS)
+        self.assertEqual([sbol2.SO_PROMOTER, sbol2.SO_MISC, sbol2.SO_CDS], c.roles)
+        c.removeRole(1)
+        self.assertEqual([sbol2.SO_PROMOTER, sbol2.SO_CDS], c.roles)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_componentdefinition.py
+++ b/test/test_componentdefinition.py
@@ -581,7 +581,8 @@ class TestAssemblyRoutines(unittest.TestCase):
         cd.addType(sbol2.BIOPAX_RNA)
         self.assertEqual([sbol2.BIOPAX_DNA, sbol2.BIOPAX_RNA], cd.types)
         cd.addType(sbol2.BIOPAX_COMPLEX)
-        self.assertEqual([sbol2.BIOPAX_DNA, sbol2.BIOPAX_RNA, sbol2.BIOPAX_COMPLEX], cd.types)
+        expected = [sbol2.BIOPAX_DNA, sbol2.BIOPAX_RNA, sbol2.BIOPAX_COMPLEX]
+        self.assertEqual(expected, cd.types)
         cd.removeType(1)
         self.assertEqual([sbol2.BIOPAX_DNA, sbol2.BIOPAX_COMPLEX], cd.types)
 

--- a/test/test_componentdefinition.py
+++ b/test/test_componentdefinition.py
@@ -575,6 +575,16 @@ class TestAssemblyRoutines(unittest.TestCase):
         cd.removeRole(1)
         self.assertEqual([sbol2.SO_PROMOTER, sbol2.SO_CDS], cd.roles)
 
+    def test_add_remove_type(self):
+        cd = sbol2.ComponentDefinition('c1')
+        self.assertEqual([sbol2.BIOPAX_DNA], cd.types)
+        cd.addType(sbol2.BIOPAX_RNA)
+        self.assertEqual([sbol2.BIOPAX_DNA, sbol2.BIOPAX_RNA], cd.types)
+        cd.addType(sbol2.BIOPAX_COMPLEX)
+        self.assertEqual([sbol2.BIOPAX_DNA, sbol2.BIOPAX_RNA, sbol2.BIOPAX_COMPLEX], cd.types)
+        cd.removeType(1)
+        self.assertEqual([sbol2.BIOPAX_DNA, sbol2.BIOPAX_COMPLEX], cd.types)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_componentdefinition.py
+++ b/test/test_componentdefinition.py
@@ -563,6 +563,18 @@ class TestAssemblyRoutines(unittest.TestCase):
                                    terminator.identity]
         self.assertEqual(primary_structure, valid_primary_structure)
 
+    def test_add_remove_role(self):
+        cd = sbol2.ComponentDefinition('c1')
+        self.assertEqual([], cd.roles)
+        cd.addRole(sbol2.SO_PROMOTER)
+        self.assertEqual([sbol2.SO_PROMOTER], cd.roles)
+        cd.addRole(sbol2.SO_MISC)
+        self.assertEqual([sbol2.SO_PROMOTER, sbol2.SO_MISC], cd.roles)
+        cd.addRole(sbol2.SO_CDS)
+        self.assertEqual([sbol2.SO_PROMOTER, sbol2.SO_MISC, sbol2.SO_CDS], cd.roles)
+        cd.removeRole(1)
+        self.assertEqual([sbol2.SO_PROMOTER, sbol2.SO_CDS], cd.roles)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_document.py
+++ b/test/test_document.py
@@ -200,9 +200,6 @@ class TestDocument(unittest.TestCase):
         namespaces = [n[1] for n in doc.graph.namespace_manager.namespaces()]
         self.assertFalse('http://examples.org#' in namespaces)
         doc.addNamespace('http://examples.org#', 'examples')
-        cd.foo = sbol.property.LiteralProperty(cd, 'http://examples.org#foo',
-                                               '0', '1', None, 'bar')
-        namespaces = [n for n in doc.graph.namespace_manager.namespaces()]
         doc.readString(doc.writeString())
         namespaces = [n for n in doc.graph.namespace_manager.namespaces()]
         self.assertIn(('examples', rdflib.URIRef('http://examples.org#')),

--- a/test/test_document.py
+++ b/test/test_document.py
@@ -308,16 +308,17 @@ class TestDocument(unittest.TestCase):
         self.assertTrue(doc)
 
     def test_from_user_to_user(self):
-        # Test proper conversion of user-facing types from RDFlib types after
+        # Test proper conversion of user-facing types from RDFlib types
         # through the Property interfaces after serializing and de-serializing
         doc = sbol.Document()
         cd = doc.componentDefinitions.create('cd')
         cd.int_property = sbol.IntProperty(cd, 'http://examples.org', '0', '1', None, 42)
+        self.assertEqual(42, cd.int_property)
         doc2 = sbol.Document()
         doc2.readString(doc.writeString())
-        cd = doc2.componentDefinitions['cd']
-        cd.int_property = sbol.IntProperty(cd, 'http://examples.org', '0', '1', None)
-        self.assertEqual(cd.int_property.value, 42)
+        cd2 = doc2.componentDefinitions['cd']
+        cd2.int_property = sbol.IntProperty(cd, 'http://examples.org', '0', '1', None)
+        self.assertEqual(42, cd2.int_property)
 
     def test_range(self):
         # Test proper serializing and de-serializing of range properties

--- a/test/test_document.py
+++ b/test/test_document.py
@@ -472,7 +472,8 @@ class TestDocumentExtensionObjects(unittest.TestCase):
         doc = sbol2.Document()
         sbol1_spec = 'http://www.nature.com/nbt/journal/v32/n6/full/nbt.2891.html'
         sbol2_spec = 'https://doi.org/10.1515/jib-2018-0001'
-        sbol3_spec = 'https://sbolstandard.org/wp-content/uploads/2020/04/SBOL3.0specification.pdf'
+        sbol3_spec = ('https://sbolstandard.org/wp-content'
+                      '/uploads/2020/04/SBOL3.0specification.pdf')
         self.assertEqual([], doc.citations)
         doc.addCitation(sbol1_spec)
         self.assertEqual([sbol1_spec], doc.citations)

--- a/test/test_document.py
+++ b/test/test_document.py
@@ -468,6 +468,38 @@ class TestDocumentExtensionObjects(unittest.TestCase):
         obj = doc.find(ntle.identity)
         self.assertIsNone(obj)
 
+    def test_add_remove_citation(self):
+        doc = sbol2.Document()
+        sbol1_spec = 'http://www.nature.com/nbt/journal/v32/n6/full/nbt.2891.html'
+        sbol2_spec = 'https://doi.org/10.1515/jib-2018-0001'
+        sbol3_spec = 'https://sbolstandard.org/wp-content/uploads/2020/04/SBOL3.0specification.pdf'
+        self.assertEqual([], doc.citations)
+        doc.addCitation(sbol1_spec)
+        self.assertEqual([sbol1_spec], doc.citations)
+        doc.addCitation(sbol2_spec)
+        self.assertEqual([sbol1_spec, sbol2_spec], doc.citations)
+        doc.addCitation(sbol3_spec)
+        expected = [sbol1_spec, sbol2_spec, sbol3_spec]
+        self.assertEqual(expected, doc.citations)
+        doc.removeCitation(1)
+        self.assertEqual([sbol1_spec, sbol3_spec], doc.citations)
+
+    def test_add_remove_keyword(self):
+        doc = sbol2.Document()
+        keyword1 = 'http://example.com/keyword#key1'
+        keyword2 = 'http://example.com/keyword#key2'
+        keyword3 = 'http://example.com/keyword#key3'
+        self.assertEqual([], doc.keywords)
+        doc.addKeyword(keyword1)
+        self.assertEqual([keyword1], doc.keywords)
+        doc.addKeyword(keyword2)
+        self.assertEqual([keyword1, keyword2], doc.keywords)
+        doc.addKeyword(keyword3)
+        expected = [keyword1, keyword2, keyword3]
+        self.assertEqual(expected, doc.keywords)
+        doc.removeKeyword(1)
+        self.assertEqual([keyword1, keyword3], doc.keywords)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_measurement.py
+++ b/test/test_measurement.py
@@ -1,0 +1,22 @@
+import unittest
+import sbol2
+
+
+class TestMeasurement(unittest.TestCase):
+
+    def test_add_remove_type(self):
+        measurement = sbol2.Measurement()
+        self.assertEqual([], measurement.types)
+        measurement.addType(sbol2.BIOPAX_DNA)
+        self.assertEqual([sbol2.BIOPAX_DNA], measurement.types)
+        measurement.addType(sbol2.BIOPAX_RNA)
+        self.assertEqual([sbol2.BIOPAX_DNA, sbol2.BIOPAX_RNA], measurement.types)
+        measurement.addType(sbol2.BIOPAX_COMPLEX)
+        expected = [sbol2.BIOPAX_DNA, sbol2.BIOPAX_RNA, sbol2.BIOPAX_COMPLEX]
+        self.assertEqual(expected, measurement.types)
+        measurement.removeType(1)
+        self.assertEqual([sbol2.BIOPAX_DNA, sbol2.BIOPAX_COMPLEX], measurement.types)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_moduledefinition.py
+++ b/test/test_moduledefinition.py
@@ -54,6 +54,18 @@ class TestModuleDefinition(unittest.TestCase):
         md.attachments = attachment.identity
         self.assertEqual([attachment.identity], md.attachments)
 
+    def test_add_remove_role(self):
+        md = sbol2.ModuleDefinition('c1')
+        self.assertEqual([], md.roles)
+        md.addRole(sbol2.SO_PROMOTER)
+        self.assertEqual([sbol2.SO_PROMOTER], md.roles)
+        md.addRole(sbol2.SO_MISC)
+        self.assertEqual([sbol2.SO_PROMOTER, sbol2.SO_MISC], md.roles)
+        md.addRole(sbol2.SO_CDS)
+        self.assertEqual([sbol2.SO_PROMOTER, sbol2.SO_MISC, sbol2.SO_CDS], md.roles)
+        md.removeRole(1)
+        self.assertEqual([sbol2.SO_PROMOTER, sbol2.SO_CDS], md.roles)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_participation.py
+++ b/test/test_participation.py
@@ -1,0 +1,21 @@
+import unittest
+import sbol2
+
+
+class TestParticipation(unittest.TestCase):
+
+    def test_add_remove_role(self):
+        p = sbol2.Participation('p')
+        self.assertEqual([], p.roles)
+        p.addRole(sbol2.SO_PROMOTER)
+        self.assertEqual([sbol2.SO_PROMOTER], p.roles)
+        p.addRole(sbol2.SO_MISC)
+        self.assertEqual([sbol2.SO_PROMOTER, sbol2.SO_MISC], p.roles)
+        p.addRole(sbol2.SO_CDS)
+        self.assertEqual([sbol2.SO_PROMOTER, sbol2.SO_MISC, sbol2.SO_CDS], p.roles)
+        p.removeRole(1)
+        self.assertEqual([sbol2.SO_PROMOTER, sbol2.SO_CDS], p.roles)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_provo.py
+++ b/test/test_provo.py
@@ -12,3 +12,33 @@ class TestProvo(unittest.TestCase):
         activity = doc.activities.create('spying')
         activity.agent = agent
         self.assertEqual(activity.agent, agent.identity)
+
+
+class TestAssociation(unittest.TestCase):
+
+    def test_add_remove_role(self):
+        a = sbol2.Association('a1')
+        self.assertEqual([], a.roles)
+        a.addRole(sbol2.SO_PROMOTER)
+        self.assertEqual([sbol2.SO_PROMOTER], a.roles)
+        a.addRole(sbol2.SO_MISC)
+        self.assertEqual([sbol2.SO_PROMOTER, sbol2.SO_MISC], a.roles)
+        a.addRole(sbol2.SO_CDS)
+        self.assertEqual([sbol2.SO_PROMOTER, sbol2.SO_MISC, sbol2.SO_CDS], a.roles)
+        a.removeRole(1)
+        self.assertEqual([sbol2.SO_PROMOTER, sbol2.SO_CDS], a.roles)
+
+
+class TestUsage(unittest.TestCase):
+
+    def test_add_remove_role(self):
+        usage = sbol2.Usage('a1')
+        self.assertEqual([], usage.roles)
+        usage.addRole(sbol2.SO_PROMOTER)
+        self.assertEqual([sbol2.SO_PROMOTER], usage.roles)
+        usage.addRole(sbol2.SO_MISC)
+        self.assertEqual([sbol2.SO_PROMOTER, sbol2.SO_MISC], usage.roles)
+        usage.addRole(sbol2.SO_CDS)
+        self.assertEqual([sbol2.SO_PROMOTER, sbol2.SO_MISC, sbol2.SO_CDS], usage.roles)
+        usage.removeRole(1)
+        self.assertEqual([sbol2.SO_PROMOTER, sbol2.SO_CDS], usage.roles)

--- a/test/test_sequenceannotation.py
+++ b/test/test_sequenceannotation.py
@@ -1,0 +1,21 @@
+import unittest
+import sbol2
+
+
+class TestSequenceAnnotation(unittest.TestCase):
+
+    def test_add_remove_role(self):
+        sa = sbol2.SequenceAnnotation()
+        self.assertEqual([], sa.roles)
+        sa.addRole(sbol2.SO_PROMOTER)
+        self.assertEqual([sbol2.SO_PROMOTER], sa.roles)
+        sa.addRole(sbol2.SO_MISC)
+        self.assertEqual([sbol2.SO_PROMOTER, sbol2.SO_MISC], sa.roles)
+        sa.addRole(sbol2.SO_CDS)
+        self.assertEqual([sbol2.SO_PROMOTER, sbol2.SO_MISC, sbol2.SO_CDS], sa.roles)
+        sa.removeRole(1)
+        self.assertEqual([sbol2.SO_PROMOTER, sbol2.SO_CDS], sa.roles)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
`ReferencedObject` and `OwnedObject` are already transparent in that they are effectively
hidden by `SBOLObject.__getattribute__` and `SBOLObject.__setattr__`. Continue that work by making `LiteralProperty` attributes (`IntProperty`, `TextProperty`) and `URIProperty` attributes transparent too.

Fixes #267 