### PR TITLE
Fix unset singleton OwnedObject property

### DIFF
--- a/sbol2/property.py
+++ b/sbol2/property.py
@@ -682,7 +682,11 @@ class OwnedObject(Property):
     def get(self, uri=''):
         # TODO: orig getter contains a size check when uri is a constant string
         if uri == '':
-            return self._sbol_owner.owned_objects[self._rdf_type][0]
+            object_store = self._sbol_owner.owned_objects[self._rdf_type]
+            if object_store:
+                return object_store[0]
+            else:
+                return None
         else:
             return self.__getitem__(uri)
 
@@ -761,7 +765,9 @@ class OwnedObject(Property):
         # TODO: This can leave the attribute empty if `add` fails.
         # Can we capture that and sent the old value back again?
         if new_value is None:
-            self.remove(self.get().identity)
+            value = self.get()
+            if value is not None:
+                self.remove(value.identity)
             return
         self._sbol_owner.owned_objects[self._rdf_type].clear()
         self.add(new_value)

--- a/sbol2/property.py
+++ b/sbol2/property.py
@@ -760,9 +760,10 @@ class OwnedObject(Property):
         #
         # TODO: This can leave the attribute empty if `add` fails.
         # Can we capture that and sent the old value back again?
-        self._sbol_owner.owned_objects[self._rdf_type].clear()
         if new_value is None:
+            self.remove(self.get().identity)
             return
+        self._sbol_owner.owned_objects[self._rdf_type].clear()
         self.add(new_value)
 
     def setPropertyValueList(self, new_value):
@@ -800,6 +801,7 @@ class OwnedObject(Property):
                 if obj.doc is not None and obj.doc.find(obj.identity) is not None:
                     obj.doc = None  # TODO not sure what this does
                 del object_store[index]
+                self.validate(None)
         else:
             raise Exception('This property is not defined in '
                             'the parent object')
@@ -817,6 +819,7 @@ class OwnedObject(Property):
                         # Erase nested, hidden TopLevel objects from Document
                         if obj.doc is not None and obj.doc.find(uri) is not None:
                             obj.doc = None  # TODO not sure what this does
+                        self.validate(None)
                         return obj
 
     def clear(self):

--- a/sbol2/property.py
+++ b/sbol2/property.py
@@ -761,6 +761,8 @@ class OwnedObject(Property):
         # TODO: This can leave the attribute empty if `add` fails.
         # Can we capture that and sent the old value back again?
         self._sbol_owner.owned_objects[self._rdf_type].clear()
+        if new_value is None:
+            return
         self.add(new_value)
 
     def setPropertyValueList(self, new_value):

--- a/test/test_property.py
+++ b/test/test_property.py
@@ -2,7 +2,7 @@ import unittest
 import os
 
 import sbol2
-from sbol2.property import OwnedObject
+
 # backward compatibility
 import sbol2 as sbol
 
@@ -154,6 +154,7 @@ class TestProperty(unittest.TestCase):
 
         # Test unsetting
         cd.annotation = None
+        self.assertEqual(cd.annotation, None)
 
     def test_owned_object_multiple(self):
         cd = sbol.ComponentDefinition('cd')

--- a/test/test_property.py
+++ b/test/test_property.py
@@ -2,6 +2,7 @@ import unittest
 import os
 
 import sbol2
+from sbol2.property import OwnedObject
 # backward compatibility
 import sbol2 as sbol
 
@@ -150,6 +151,9 @@ class TestProperty(unittest.TestCase):
         self.assertIsNone(cd.annotation)
         cd.annotation = sbol.Identified('foo')
         self.assertEqual(type(cd.annotation), sbol.Identified)
+
+        # Test unsetting
+        cd.annotation = None
 
     def test_owned_object_multiple(self):
         cd = sbol.ComponentDefinition('cd')

--- a/test/test_property.py
+++ b/test/test_property.py
@@ -155,6 +155,8 @@ class TestProperty(unittest.TestCase):
         # Test unsetting
         cd.annotation = None
         self.assertEqual(cd.annotation, None)
+        cd.annotation = None
+        self.assertEqual(cd.annotation, None)
 
     def test_owned_object_multiple(self):
         cd = sbol.ComponentDefinition('cd')


### PR DESCRIPTION
- Allow user to unset a singleton OwnedObject property by assigning None
- Add validation to `remove` methods
- Fix #269 
