### PR TITLE
Ensure that autoconstruction of Sequence URIs works correctly with di…

### DIFF
--- a/sbol2/componentdefinition.py
+++ b/sbol2/componentdefinition.py
@@ -324,13 +324,10 @@ class ComponentDefinition(TopLevel):
                              'to a Document in order to compile.' % self.identity)
 
         if self.sequence is None:
-            if Config.getOption('sbol_compliant_uris'):
-                display_id = self.displayId
-                if not Config.getOption('sbol_typed_uris'):
-                    display_id += '_seq'
-                self.sequence = Sequence(display_id)
-            else:
-                self.sequence = Sequence(display_id + '_seq')
+            sequence_id = self.displayId + '_seq'
+            if Config.getOption('sbol_compliant_uris') and Config.getOption('sbol_typed_uris'):
+                sequence_id = self.displayId
+            self.sequence = Sequence(sequence_id)
 
         return self.sequence.compile(assembly_method=assembly_method)
 

--- a/test/test_componentdefinition.py
+++ b/test/test_componentdefinition.py
@@ -337,6 +337,32 @@ class TestAssemblyRoutines(unittest.TestCase):
         self.assertEqual(target_seq, 'aaatttaaatttaaatttaaa')
         self.assertEqual(target_seq, gene.sequence.elements)
 
+    def test_compile_autoconstruct_sequence(self):
+        # Ensure that autoconstruction of Sequence URIs works correctly with
+        # different configuration options
+        root_id = 'root'
+        sub_id = 'sub'
+        sbol2.Config.setOption('sbol_compliant_uris', True)
+        sbol2.Config.setOption('sbol_typed_uris', True)
+        doc = sbol2.Document()
+        root = doc.componentDefinitions.create(root_id)
+        sub = doc.componentDefinitions.create(sub_id)
+        root.compile([sub])
+        expected_identity = sbol2.getHomespace() + '/Sequence/' + root_id + '/1'
+        self.assertEqual(root.sequence.identity, expected_identity)
+
+        sbol2.Config.setOption('sbol_compliant_uris', True)
+        sbol2.Config.setOption('sbol_typed_uris', False)
+        doc = sbol2.Document()
+        root = doc.componentDefinitions.create(root_id)
+        sub = doc.componentDefinitions.create(sub_id)
+        root.compile([sub])
+        expected_identity = sbol2.getHomespace() + '/' + root_id + '_seq/1'
+        self.assertEqual(root.sequence.identity, expected_identity)
+
+        sbol2.Config.setOption('sbol_compliant_uris', True)
+        sbol2.Config.setOption('sbol_typed_uris', True)
+
     def test_recursive_compile(self):
         doc = sbol2.Document()
         cd1 = sbol2.ComponentDefinition('cd1')


### PR DESCRIPTION
- Fix #264 
- Ensure that `compile` method autoconstructs associated Sequences correctly
- Ensure that autoconstructed Sequence URIs are unique and do not cause URI collision
- Ensure that autoconstruction works with different configuration options
