### PR TITLE
Don't wipe the document when appending

### DIFF
--- a/sbol2/document.py
+++ b/sbol2/document.py
@@ -412,15 +412,10 @@ class Document(Identified):
         :param sbol_str: A string formatted in SBOL.
         :return: None
         """
-        if not self.graph:
-            self.graph = rdflib.Graph()
         # Save any changes we've made to the graph.
         self.update_graph()
         # Use rdflib to automatically merge the graphs together
         self.graph.parse(data=sbol_str, format="application/rdf+xml")
-        # Clean up our internal data structures.
-        # (There's probably a more efficient way to merge.)
-        self.clear(clear_graph=False)
         # Base our internal representation on the new graph.
         self.parse_all()
 
@@ -430,8 +425,6 @@ class Document(Identified):
 
         :return: A string representation of the objects in this Document.
         """
-        if not self.graph:
-            self.graph = rdflib.Graph()
         # Save any changes we've made to the graph.
         self.update_graph()
         # Write graph to string
@@ -454,9 +447,6 @@ class Document(Identified):
         self.update_graph()
         # Use rdflib to automatically merge the graphs together
         self.graph.parse(filename, format="application/rdf+xml")
-        # Clean up our internal data structures.
-        # (There's probably a more efficient way to merge.)
-        self.clear(clear_graph=False)
         # Base our internal representation on the new graph.
         self.parse_all()
 
@@ -565,14 +555,15 @@ class Document(Identified):
                 # a list property, an owned property or a referenced property
                 if predicate in parent.properties:
                     # triple is a property
-                    parent.properties[predicate].append(obj)
+                    if obj not in parent.properties[predicate]:
+                        parent.properties[predicate].append(obj)
                 elif predicate in parent.owned_objects:
                     # triple is an owned object
                     owned_obj = self.SBOLObjects[obj]
                     if owned_obj is not None:
-                        parent.owned_objects[predicate].append(owned_obj)
-                        owned_obj.parent = parent
-                        # del self.SBOLObjects[obj]
+                        if owned_obj not in parent.owned_objects[predicate]:
+                            parent.owned_objects[predicate].append(owned_obj)
+                            owned_obj.parent = parent
                 else:
                     # Extension data
                     parent.properties[predicate] = [obj]

--- a/test/test_document.py
+++ b/test/test_document.py
@@ -501,6 +501,38 @@ class TestDocumentExtensionObjects(unittest.TestCase):
         doc.removeKeyword(1)
         self.assertEqual([keyword1, keyword3], doc.keywords)
 
+    def test_version(self):
+        doc = sbol2.Document()
+        self.assertIsNotNone(doc.version)
+        old_version = doc.version
+        doc.append(CRISPR_LOCATION)
+        self.assertIsNotNone(doc.version)
+        self.assertEqual(old_version, doc.version)
+
+    def test_idempotent_read(self):
+        doc = sbol2.Document()
+        doc.read(CRISPR_LOCATION)
+        old_len = len(doc)
+        cd_uri = 'http://sbols.org/CRISPR_Example/gRNA_b/1.0.0'
+        cd = doc.componentDefinitions[cd_uri]
+        self.assertEqual(1, len(cd.roles))
+
+        # Now load the same file again and make sure the size of the
+        # document didn't increase, and the number of roles on the
+        # ComponentDefinition didn't increase.
+        doc.append(CRISPR_LOCATION)
+        self.assertEqual(old_len, len(doc))
+        cd = doc.componentDefinitions[cd_uri]
+        self.assertEqual(1, len(cd.roles))
+
+        # Now load the file one more time and make sure the size of the
+        # document didn't increase, and the number of roles on the
+        # ComponentDefinition didn't increase.
+        doc.append(CRISPR_LOCATION)
+        self.assertEqual(old_len, len(doc))
+        cd = doc.componentDefinitions[cd_uri]
+        self.assertEqual(1, len(cd.roles))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_partshop.py
+++ b/test/test_partshop.py
@@ -257,3 +257,18 @@ WHERE {
         self.assertEqual(10, len(doc))
         for cd in doc.componentDefinitions:
             self.assertIn(sbol2.SO_PROMOTER, cd.roles)
+
+    def test_pull_doc_version(self):
+        # After a pull the document version was erroneously set to None (#281)
+        doc = sbol.Document()
+        self.assertIsNotNone(doc.version)
+        old_version = doc.version
+        igem = sbol.PartShop('https://synbiohub.org')
+        igem.pull('https://synbiohub.org/public/igem/BBa_R0010/1', doc)
+        self.assertEqual(3, len(doc))
+        self.assertIsNotNone(doc.version)
+        self.assertEqual(old_version, doc.version)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
When reading additional material into an existing Document, do not wipe
the contents of the Document. Properties like version should remain
after the read.

Fixes #281 