### PR TITLE
Fix testHasUpstreamComponent

### DIFF
--- a/sbol2/property.py
+++ b/sbol2/property.py
@@ -6,6 +6,7 @@ import posixpath
 
 import rdflib
 from rdflib import Literal, URIRef
+import packaging.version as pv
 
 from .config import Config
 from .config import ConfigOptions
@@ -626,11 +627,11 @@ class OwnedObject(Property):
         # if a match, store it. If another match, check versions and keep
         # the newer one.
         found_object = None
-        found_version = -math.inf
+        found_version = pv.NegativeInfinity
         object_store = self._sbol_owner.owned_objects[self._rdf_type]
         for obj in object_store:
             if obj.identity.startswith(search_uri):
-                obj_version = float(obj.version)
+                obj_version = pv.parse(obj.version)
                 if obj_version > found_version:
                     found_object = obj
                     found_version = obj_version

--- a/setup.py
+++ b/setup.py
@@ -29,10 +29,10 @@ setup(name='sbol2',
       keywords='synthetic biology',
       packages=['sbol2'],
       install_requires=[
-            'rdflib',
+            'rdflib>=5.0',
             'deprecated',
             'lxml',
             'requests',
             'urllib3',
-            'packaging'
+            'packaging>=20.0'
       ])

--- a/setup.py
+++ b/setup.py
@@ -33,5 +33,6 @@ setup(name='sbol2',
             'deprecated',
             'lxml',
             'requests',
-            'urllib3'
+            'urllib3',
+            'packaging'
       ])

--- a/test/test_componentdefinition.py
+++ b/test/test_componentdefinition.py
@@ -126,20 +126,22 @@ class TestComponentDefinitions(unittest.TestCase):
                                    cds.identity, terminator.identity]
         self.assertListEqual(primary_structure, valid_primary_structure)
 
-    @unittest.expectedFailure
     def testHasUpstreamComponent(self):
         uri = 'http://sbols.org/CRISPR_Example/gRNA_b_gene/1.0.0'
         doc = sbol2.Document()
         doc.read(CRISPR_EXAMPLE)
         cd = doc.componentDefinitions.get(uri)
         self.assertIsNotNone(cd)
-        comps = {
-            'http://sbols.org/CRISPR_Example/gRNA_b_gene/CRa_U6/1.0.0': True,
-            'http://sbols.org/CRISPR_Example/gRNA_b_gene/CRa_U6/1.0.0': True,
-            'http://sbols.org/CRISPR_Example/gRNA_b_gene/CRa_U6/1.0.0': False
-        }
+        # First element, has no upstream component
         uri = 'http://sbols.org/CRISPR_Example/gRNA_b_gene/CRa_U6/1.0.0'
-        print(cd.getPrimaryStructure())
+        c = cd.components.get(uri)
+        self.assertFalse(cd.hasUpstreamComponent(c))
+        # Second element has above as upstream component
+        uri = 'http://sbols.org/CRISPR_Example/gRNA_b_gene/gRNA_b_nc/1.0.0'
+        c = cd.components.get(uri)
+        self.assertTrue(cd.hasUpstreamComponent(c))
+        # Third element has both above as upstream components
+        uri = 'http://sbols.org/CRISPR_Example/gRNA_b_gene/gRNA_b_terminator/1.0.0'
         c = cd.components.get(uri)
         self.assertTrue(cd.hasUpstreamComponent(c))
 


### PR DESCRIPTION
Fix the remaining errors in testHasUpstreamComponent so that it now serves as a valid unit test. This includes adding the "packaging" modules as a dependency so that we can parse version numbers. That will come in handy later when we implement `VersionProperty` (See #96).

Fixes #246 
