### PR TITLE
Keep version on Document.clear()

### DIFF
--- a/sbol2/document.py
+++ b/sbol2/document.py
@@ -688,9 +688,14 @@ class Document(Identified):
 
         :return: None
         """
+        # Properties to keep, which don't make sense to clear
+        keepers = [SBOL_VERSION]
         self.SBOLObjects.clear()
-        for name, vals in self.properties.items():
-            vals.clear()
+        for name, value in self.properties.items():
+            if name in keepers:
+                # Do not erase properties on the keepers list
+                continue
+            value.clear()
         for object_store in self.owned_objects.values():
             object_store.clear()
         self._namespaces.clear()


### PR DESCRIPTION
When clearing the document, hold on to the version number.

Fixes #284 