### PR TITLE
Return None if a TextProperty value is the empty string

### DIFF
--- a/sbol2/document.py
+++ b/sbol2/document.py
@@ -208,7 +208,7 @@ class Document(Identified):
         :return: None
         """
         # Check for uniqueness of URI
-        identity_uri = rdflib.URIRef(sbol_obj.identity)
+        identity_uri = sbol_obj.identity
         if identity_uri in self.SBOLObjects:
             raise SBOLError('Cannot add ' + sbol_obj.identity +
                             ' to Document. An object with this identity '

--- a/sbol2/document.py
+++ b/sbol2/document.py
@@ -1033,8 +1033,8 @@ def IGEM_STANDARD_ASSEMBLY(parts_list):
     G0000_seq_uri = 'https://synbiohub.org/public/igem/BBa_G0000_sequence/1'
     G0002_uri = 'https://synbiohub.org/public/igem/BBa_G0002/1'
     G0002_seq_uri = 'https://synbiohub.org/public/igem/BBa_G0002_sequence/1'
-    if not (G0000_uri in doc.componentDefinitions and G0002_uri in doc.componentDefinitions and G0000_seq_uri \
-            in doc.sequences and G0002_seq_uri in doc.sequences):
+    if not (G0000_uri in doc.componentDefinitions and G0002_uri in doc.componentDefinitions
+            and G0000_seq_uri in doc.sequences and G0002_seq_uri in doc.sequences):
         doc.readString('''<?xml version="1.0" encoding="utf-8"?>
                    <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/"
                    xmlns:dcterms="http://purl.org/dc/terms/"

--- a/sbol2/identified.py
+++ b/sbol2/identified.py
@@ -88,7 +88,7 @@ class Identified(SBOLObject):
         self.persistentIdentity = URIProperty(self, SBOL_PERSISTENT_IDENTITY,
                                               '0', '1', None, URIRef(uri))
         self.displayId = TextProperty(self, SBOL_DISPLAY_ID, '0', '1',
-                                         [validation.sbol_rule_10204])
+                                      [validation.sbol_rule_10204])
         self.version = LiteralProperty(self, SBOL_VERSION, '0', '1', None, version)
         self.name = TextProperty(self, SBOL_NAME, '0', '1', None)
         self.description = TextProperty(self, SBOL_DESCRIPTION, '0', '1', None)

--- a/sbol2/identified.py
+++ b/sbol2/identified.py
@@ -9,7 +9,7 @@ from .config import getHomespace
 from .config import hasHomespace
 from .constants import *
 from .property import LiteralProperty
-from .property import ReferencedObject
+from .property import ReferencedObject, TextProperty
 from .property import URIProperty
 from .sbolerror import SBOLError
 from .sbolerror import SBOLErrorCode
@@ -87,11 +87,11 @@ class Identified(SBOLObject):
         super().__init__(type_uri, uri)
         self.persistentIdentity = URIProperty(self, SBOL_PERSISTENT_IDENTITY,
                                               '0', '1', None, URIRef(uri))
-        self.displayId = LiteralProperty(self, SBOL_DISPLAY_ID, '0', '1',
+        self.displayId = TextProperty(self, SBOL_DISPLAY_ID, '0', '1',
                                          [validation.sbol_rule_10204])
         self.version = LiteralProperty(self, SBOL_VERSION, '0', '1', None, version)
-        self.name = LiteralProperty(self, SBOL_NAME, '0', '1', None)
-        self.description = LiteralProperty(self, SBOL_DESCRIPTION, '0', '1', None)
+        self.name = TextProperty(self, SBOL_NAME, '0', '1', None)
+        self.description = TextProperty(self, SBOL_DESCRIPTION, '0', '1', None)
         if Config.getOption(ConfigOptions.SBOL_COMPLIANT_URIS.value) is True:
             self.displayId = uri
             self.persistentIdentity = URIRef(posixpath.join(getHomespace(), uri))

--- a/sbol2/property.py
+++ b/sbol2/property.py
@@ -463,8 +463,12 @@ class TextProperty(LiteralProperty):
     # methods out of LiteralProperty and into TextProperty. Then make
     # LiteralProperty an abstract base class.
 
-    # For now, this class is just an alias to LiteralProperty
-    pass
+    def convert_to_user(self, value):
+        result = str(value)
+        if result == '':
+            # special case, empty strings are equivalent to None
+            return None
+        return result
 
 
 class OwnedObject(Property):

--- a/sbol2/property.py
+++ b/sbol2/property.py
@@ -307,17 +307,13 @@ class URIProperty(Property):
             self.setPropertyValueList(new_value)
 
     def setSinglePropertyValue(self, new_value):
-        if type(new_value) is list:
-            raise TypeError('The ' + str(self.getTypeURI()) +
-                            ' property does not accept list arguments.')
-        if self._rdf_type not in self._sbol_owner.properties:
-            self._sbol_owner.properties[self._rdf_type] = []
+        new_value = self.convert_from_user(new_value)
+        # clear out any old value
+        self._sbol_owner.properties[self._rdf_type].clear()
         if new_value is None:
+            # We've already cleared the value, do nothing else.
             return
-        elif len(self._sbol_owner.properties[self._rdf_type]) == 0:
-            self._sbol_owner.properties[self._rdf_type].append(URIRef(new_value))
-        else:
-            self._sbol_owner.properties[self._rdf_type][-1] = URIRef(new_value)
+        self._sbol_owner.properties[self._rdf_type].append(new_value)
 
     def setPropertyValueList(self, value):
         if value is None:
@@ -339,7 +335,11 @@ class URIProperty(Property):
         self.value += [new_value]
 
     def convert_to_user(self, value):
-        return str(value)
+        result = str(value)
+        if result == '':
+            # special case, empty strings are equivalent to None
+            return None
+        return result
 
     def convert_from_user(self, value):
         # None is ok iff upper bound is 1 and lower bound is 0.

--- a/test/test_componentdefinition.py
+++ b/test/test_componentdefinition.py
@@ -254,10 +254,6 @@ class TestComponentDefinitions(unittest.TestCase):
         self.assertIsNotNone(cd.sequence)
         self.assertIs(cd.sequence, doc.getSequence(cd.sequence.identity))
 
-    @unittest.expectedFailure
-    def test_sequences_validation(self):
-        self.fail('Not yet implemented')
-
 
 class TestAssemblyRoutines(unittest.TestCase):
 

--- a/test/test_property.py
+++ b/test/test_property.py
@@ -36,7 +36,7 @@ class TestProperty(unittest.TestCase):
         plasmid.removeRole()
         self.assertEqual(len(plasmid.roles), 1)
 
-    def test_unsetSingletonProperty(self):
+    def test_unset_text_property(self):
         doc = sbol.Document()
         cd = doc.componentDefinitions.create('cd')
         cd.name = 'foo'
@@ -47,6 +47,18 @@ class TestProperty(unittest.TestCase):
         self.assertEqual(cd.name, 'foo')
         cd.name = ''
         self.assertEqual(cd.name, None)
+
+    def test_unset_uri_property(self):
+        doc = sbol.Document()
+        cd = doc.componentDefinitions.create('cd')
+        cd.persistentIdentity = 'foo'
+        self.assertEqual('foo', cd.persistentIdentity)
+        cd.persistentIdentity = None
+        self.assertEqual(None, cd.persistentIdentity)
+        cd.persistentIdentity = 'foo'
+        self.assertEqual('foo', cd.persistentIdentity)
+        cd.persistentIdentity = ''
+        self.assertEqual(None, cd.persistentIdentity)
 
     def test_unsetListProperty(self):
         plasmid = sbol.ComponentDefinition('pBB1', sbol.BIOPAX_DNA, '1.0.0')

--- a/test/test_property.py
+++ b/test/test_property.py
@@ -36,7 +36,6 @@ class TestProperty(unittest.TestCase):
         plasmid.removeRole()
         self.assertEqual(len(plasmid.roles), 1)
 
-    @unittest.expectedFailure  # See #93
     def test_unsetSingletonProperty(self):
         doc = sbol.Document()
         cd = doc.componentDefinitions.create('cd')


### PR DESCRIPTION
Per history and a [discussion on a google forum](https://groups.google.com/forum/#!msg/sbol-dev/r95K7mtkEGU/2KJMNKZWBQAJ), if a TextProperty is set to
the empty string, and then accessed, return None. This allows an
expectedFailure unit test to run successfully.

Fixes #93 