### PR TITLE
Implement FloatProperty, DateTimeProperty, and VersionProperty

### DIFF
--- a/dev/hooks/pre-commit
+++ b/dev/hooks/pre-commit
@@ -14,7 +14,7 @@ EOF
 fi 
 
 # Run style checker
-MAX_VIOLATIONS=25
+MAX_VIOLATIONS=23
 echo "Checking style..."
 pycodestyle sbol2 test > style.txt
 result=$(cat style.txt | wc -l)

--- a/sbol2/attachment.py
+++ b/sbol2/attachment.py
@@ -2,7 +2,7 @@ from rdflib import URIRef
 
 from .toplevel import TopLevel
 from .constants import *
-from .property import URIProperty, LiteralProperty
+from .property import URIProperty, IntProperty, TextProperty
 
 
 class Attachment(TopLevel):
@@ -12,6 +12,6 @@ class Attachment(TopLevel):
                  source=''):
         super().__init__(type_uri, uri, version)
         self.source = URIProperty(self, SBOL_SOURCE, '1', '1', [], source)
-        self.format = LiteralProperty(self, SBOL_URI + '#format', '0', '1', [])
-        self.size = LiteralProperty(self, SBOL_URI + '#size', '0', '1', [])
-        self.hash = LiteralProperty(self, SBOL_URI + '#hash', '0', '1', [])
+        self.format = URIProperty(self, SBOL_URI + '#format', '0', '1', [])
+        self.size = IntProperty(self, SBOL_URI + '#size', '0', '1', [])
+        self.hash = TextProperty(self, SBOL_URI + '#hash', '0', '1', [])

--- a/sbol2/identified.py
+++ b/sbol2/identified.py
@@ -8,13 +8,13 @@ from .config import ConfigOptions
 from .config import getHomespace
 from .config import hasHomespace
 from .constants import *
-from .property import LiteralProperty
 from .property import ReferencedObject, TextProperty
 from .property import URIProperty
 from .sbolerror import SBOLError
 from .sbolerror import SBOLErrorCode
 from .config import parseClassName
 from . import validation
+from .versionproperty import VersionProperty
 
 
 class Identified(SBOLObject):
@@ -89,7 +89,7 @@ class Identified(SBOLObject):
                                               '0', '1', None, URIRef(uri))
         self.displayId = TextProperty(self, SBOL_DISPLAY_ID, '0', '1',
                                       [validation.sbol_rule_10204])
-        self.version = LiteralProperty(self, SBOL_VERSION, '0', '1', None, version)
+        self.version = VersionProperty(self, SBOL_VERSION, '0', '1', None, version)
         self.name = TextProperty(self, SBOL_NAME, '0', '1', None)
         self.description = TextProperty(self, SBOL_DESCRIPTION, '0', '1', None)
         if Config.getOption(ConfigOptions.SBOL_COMPLIANT_URIS.value) is True:
@@ -99,7 +99,7 @@ class Identified(SBOLObject):
                 if self.version:
                     self.identity = URIRef(posixpath.join(getHomespace(),
                                                           self.getClassName(type_uri),
-                                                          uri, self.version))
+                                                          uri, str(self.version)))
                 else:
                     self.identity = URIRef(posixpath.join(getHomespace(),
                                                           self.getClassName(type_uri),
@@ -107,7 +107,7 @@ class Identified(SBOLObject):
             else:
                 if self.version:
                     self.identity = URIRef(posixpath.join(getHomespace(),
-                                                          uri, self.version))
+                                                          uri, str(self.version)))
                 else:
                     self.identity = URIRef(posixpath.join(getHomespace(), uri))
         elif hasHomespace():
@@ -249,7 +249,7 @@ class Identified(SBOLObject):
             # object.  However, if user is copying into a different Document, then copy
             # the original object's version without incrementing
             if new_obj.doc and new_obj.doc is self.doc and not target_namespace:
-                new_obj.version.incrementMajor()
+                new_obj.version = VersionProperty.increment_major(self.version)
             else:
                 new_obj.version = self.version
 

--- a/sbol2/identified.py
+++ b/sbol2/identified.py
@@ -250,10 +250,12 @@ class Identified(SBOLObject):
                 new_obj.version = self.version
 
         # Now set up the identity based on the persistentIdentity and maybe version
-        if Config.getOption(ConfigOptions.SBOL_COMPLIANT_URIS) and new_obj.version:
-            new_obj.identity = posixpath.join(new_obj.persistentIdentity, new_obj.version)
-        else:
-            new_obj.identity = new_obj.persistentIdentity
+        # In the case of a Document there is no persistentIdentity so skip this block
+        if new_obj.persistentIdentity:
+            if Config.getOption(ConfigOptions.SBOL_COMPLIANT_URIS) and new_obj.version:
+                new_obj.identity = posixpath.join(new_obj.persistentIdentity, new_obj.version)
+            else:
+                new_obj.identity = new_obj.persistentIdentity
 
         # Assign the new object to the target Document
         if target_doc:

--- a/sbol2/location.py
+++ b/sbol2/location.py
@@ -1,7 +1,6 @@
 from .identified import Identified
 from .constants import *
 from .property import IntProperty
-from .property import LiteralProperty
 from .property import OwnedObject
 from .property import ReferencedObject
 from .property import URIProperty

--- a/sbol2/measurement.py
+++ b/sbol2/measurement.py
@@ -1,6 +1,6 @@
 from .constants import *
 from .identified import Identified
-from .property import LiteralProperty, URIProperty
+from .property import URIProperty, FloatProperty
 
 from rdflib import URIRef
 
@@ -9,10 +9,10 @@ class Measurement(Identified):
     """The purpose of the Measure class is to link a numerical value
     to a unit of measure."""
 
-    def __init__(self, uri=URIRef('example'), value='0.0',
+    def __init__(self, uri=URIRef('example'), value=0.0,
                  unit='', version=VERSION_STRING):
         super().__init__(SBOL_MEASURE, uri, version)
-        self.value = LiteralProperty(self, SBOL_VALUE, '1', '1', [], value)
+        self.value = FloatProperty(self, SBOL_VALUE, '1', '1', [], value)
         self.unit = URIProperty(self, SBOL_UNIT, '1', '1', [], unit)
         self.types = URIProperty(self, SBOL_TYPES, '0', '*', [])
 

--- a/sbol2/property.py
+++ b/sbol2/property.py
@@ -457,6 +457,23 @@ class IntProperty(LiteralProperty):
         return Literal(value)
 
 
+class FloatProperty(LiteralProperty):
+
+    def convert_to_user(self, value):
+        return float(value)
+
+    def convert_from_user(self, value):
+        # None is ok iff upper bound is 1 and lower bound is 0.
+        # If upper bound > 1, attribute is a list and None is not a valid list
+        # If lower bound > 0, attribute must have a value, so None is unacceptable
+        if value is None and self.upper_bound == 1 and self.lower_bound == 0:
+            return None
+        if not isinstance(value, float):
+            msg = '{} values must have type float'.format(self.getTypeURI())
+            raise TypeError(msg)
+        return Literal(value)
+
+
 class TextProperty(LiteralProperty):
 
     # In the future, pull the convert_to_user and convert_from_user

--- a/sbol2/property.py
+++ b/sbol2/property.py
@@ -4,6 +4,7 @@ import collections
 import logging
 import math
 import posixpath
+from typing import Any, Union
 
 import dateutil.parser
 import rdflib
@@ -453,26 +454,27 @@ class IntProperty(LiteralProperty):
         # If lower bound > 0, attribute must have a value, so None is unacceptable
         if value is None and self.upper_bound == 1 and self.lower_bound == 0:
             return None
-        if not isinstance(value, int):
-            msg = '{} values must have type int'.format(self.getTypeURI())
-            raise TypeError(msg)
+        # Convert to int. If conversion fails a ValueError is raised
+        value = int(value)
         return Literal(value)
 
 
 class FloatProperty(LiteralProperty):
 
-    def convert_to_user(self, value):
+    def convert_to_user(self, value: rdflib.Literal) -> float:
         return float(value)
 
-    def convert_from_user(self, value):
+    def convert_from_user(self, value: Any) -> Union[rdflib.Literal, None]:
+        """
+        :raises: ValueError if value cannot be converted to float
+        """
         # None is ok iff upper bound is 1 and lower bound is 0.
         # If upper bound > 1, attribute is a list and None is not a valid list
         # If lower bound > 0, attribute must have a value, so None is unacceptable
         if value is None and self.upper_bound == 1 and self.lower_bound == 0:
             return None
-        if not isinstance(value, float):
-            msg = '{} values must have type float'.format(self.getTypeURI())
-            raise TypeError(msg)
+        # Convert to float. If conversion fails a ValueError is raised
+        value = float(value)
         return Literal(value)
 
 
@@ -491,7 +493,7 @@ class DateTimeProperty(LiteralProperty):
             value = dateutil.parser.parse(value)
         if not isinstance(value, datetime.datetime):
             msg = '{} values must have type datetime'.format(self.getTypeURI())
-            raise TypeError(msg)
+            raise ValueError(msg)
         return Literal(value)
 
 

--- a/sbol2/property.py
+++ b/sbol2/property.py
@@ -1,9 +1,11 @@
+import datetime
 from abc import ABC, abstractmethod
 import collections
 import logging
 import math
 import posixpath
 
+import dateutil.parser
 import rdflib
 from rdflib import Literal, URIRef
 import packaging.version as pv
@@ -470,6 +472,25 @@ class FloatProperty(LiteralProperty):
             return None
         if not isinstance(value, float):
             msg = '{} values must have type float'.format(self.getTypeURI())
+            raise TypeError(msg)
+        return Literal(value)
+
+
+class DateTimeProperty(LiteralProperty):
+
+    def convert_to_user(self, value):
+        return dateutil.parser.parse(value)
+
+    def convert_from_user(self, value):
+        # None is ok iff upper bound is 1 and lower bound is 0.
+        # If upper bound > 1, attribute is a list and None is not a valid list
+        # If lower bound > 0, attribute must have a value, so None is unacceptable
+        if value is None and self.upper_bound == 1 and self.lower_bound == 0:
+            return None
+        if isinstance(value, str):
+            value = dateutil.parser.parse(value)
+        if not isinstance(value, datetime.datetime):
+            msg = '{} values must have type datetime'.format(self.getTypeURI())
             raise TypeError(msg)
         return Literal(value)
 

--- a/sbol2/provo.py
+++ b/sbol2/provo.py
@@ -3,7 +3,7 @@ from rdflib import URIRef
 from . import validation
 from .constants import *
 from .identified import Identified
-from .property import LiteralProperty
+from .property import DateTimeProperty
 from .property import OwnedObject
 from .property import ReferencedObject
 from .property import URIProperty
@@ -186,10 +186,10 @@ class Activity(TopLevel):
         self.agent = ReferencedObject(self, PROVO_AGENT, Agent,
                                       '0', '1', [validation.libsbol_rule_22])
         self.types = URIProperty(self, SBOL_TYPES, '0', '1', [])
-        self.startedAtTime = LiteralProperty(self, PROVO_STARTED_AT_TIME,
-                                             '0', '1', [])
-        self.endedAtTime = LiteralProperty(self, PROVO_ENDED_AT_TIME,
-                                           '0', '1', [])
+        self.startedAtTime = DateTimeProperty(self, PROVO_STARTED_AT_TIME,
+                                              '0', '1', [])
+        self.endedAtTime = DateTimeProperty(self, PROVO_ENDED_AT_TIME,
+                                            '0', '1', [])
         self.wasInformedBy = ReferencedObject(self, PROVO_WAS_INFORMED_BY,
                                               PROVO_ACTIVITY, '0', '*', [])
         self.usages = OwnedObject(self, PROVO_QUALIFIED_USAGE, Usage,

--- a/sbol2/sequence.py
+++ b/sbol2/sequence.py
@@ -2,7 +2,7 @@ from deprecated import deprecated
 from rdflib import URIRef
 
 from .constants import *
-from .property import LiteralProperty, URIProperty
+from .property import URIProperty, TextProperty
 from .toplevel import TopLevel
 from .config import Config
 
@@ -38,8 +38,8 @@ class Sequence(TopLevel):
         # these characters could represent the nucleotide bases
         # of a molecule of DNA, the amino acid residues of a protein,
         # or the atoms and chemical bonds of a small molecule.
-        self.elements = LiteralProperty(self, SBOL_ELEMENTS,
-                                        '1', '1', [], elements)
+        self.elements = TextProperty(self, SBOL_ELEMENTS,
+                                     '1', '1', [], elements)
         self.encoding = URIProperty(self, SBOL_ENCODING,
                                     '1', '1', [], encoding)
 

--- a/sbol2/versionproperty.py
+++ b/sbol2/versionproperty.py
@@ -1,0 +1,40 @@
+from .property import LiteralProperty
+import packaging.version as pv
+import rdflib
+
+
+class VersionProperty(LiteralProperty):
+
+    def convert_to_user(self, value):
+        result = str(value)
+        if result == '':
+            # special case, empty strings are equivalent to None
+            return None
+        return result
+
+    def convert_from_user(self, value):
+        # Empty string is equivalent to None
+        if value == '':
+            value = None
+        # None is ok iff upper bound is 1 and lower bound is 0.
+        # If upper bound > 1, attribute is a list and None is not a valid list
+        # If lower bound > 0, attribute must have a value, so None is unacceptable
+        if value is None and self.upper_bound == 1 and self.lower_bound == 0:
+            return None
+        try:
+            version = pv.Version(value)
+        except pv.InvalidVersion as e:
+            raise ValueError(e)
+        except TypeError as e:
+            raise ValueError(e)
+        return rdflib.Literal(str(version))
+
+    @staticmethod
+    def _make_version(major: int, minor: int, micro: int) -> pv.Version:
+        return pv.Version(f'{major}.{minor}.{micro}')
+
+    @staticmethod
+    def increment_major(version: str) -> str:
+        old = pv.Version(version)
+        new = VersionProperty._make_version(old.major + 1, old.minor, old.micro)
+        return str(new)

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(name='sbol2',
       packages=['sbol2'],
       install_requires=[
             'rdflib>=5.0',
+            'dateutil',
             'deprecated',
             'lxml',
             'requests',

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(name='sbol2',
       packages=['sbol2'],
       install_requires=[
             'rdflib>=5.0',
-            'dateutil',
+            'python-dateutil',
             'deprecated',
             'lxml',
             'requests',

--- a/test/test_document.py
+++ b/test/test_document.py
@@ -199,8 +199,8 @@ class TestDocument(unittest.TestCase):
     def test_add_namespace(self):
         doc = sbol.Document()
         cd = doc.componentDefinitions.create('cd')
-        cd.foo = sbol.property.LiteralProperty(cd, 'http://examples.org#foo',
-                                               '0', '1', None, 'bar')
+        cd.foo = sbol.property.TextProperty(cd, 'http://examples.org#foo',
+                                            '0', '1', None, 'bar')
         doc.readString(doc.writeString())
         namespaces = [n[1] for n in doc.graph.namespace_manager.namespaces()]
         self.assertFalse('http://examples.org#' in namespaces)

--- a/test/test_identified.py
+++ b/test/test_identified.py
@@ -280,9 +280,9 @@ class TestCopy(unittest.TestCase):
         cd = sbol.ComponentDefinition('cd')
         doc.addComponentDefinition(cd)
         doc.addNamespace(extension_namespace, extension_prefix)
-        cd.extension_property = sbol.property.LiteralProperty(cd, extension_namespace +
-                                                              'extension_property', '0',
-                                                              '1', None, 'foo')
+        cd.extension_property = sbol.property.TextProperty(cd, extension_namespace +
+                                                           'extension_property', '0',
+                                                           '1', None, 'foo')
         cd_copy = cd.copy(target_doc)
         self.assertTrue(target_doc._namespaces[extension_prefix] ==
                         rdflib.URIRef(extension_namespace))

--- a/test/test_identified.py
+++ b/test/test_identified.py
@@ -287,7 +287,6 @@ class TestCopy(unittest.TestCase):
         self.assertTrue(target_doc._namespaces[extension_prefix] ==
                         rdflib.URIRef(extension_namespace))
 
-    @unittest.expectedFailure
     def test_copy_and_increment_version(self):
         # When copying an object within the same Document, the version should be
         # automatically incrememented
@@ -297,8 +296,8 @@ class TestCopy(unittest.TestCase):
         doc.addComponentDefinition(comp)
 
         comp_copy = comp.copy()
-        self.assertEqual(comp.version, rdflib.Literal('1.0.0'))
-        self.assertEqual(comp_copy.version, rdflib.Literal('2.0.0'))
+        self.assertEqual(comp.version, '1.0.0')
+        self.assertEqual(comp_copy.version, '2.0.0')
         self.assertEqual(comp_copy.identity, comp.persistentIdentity + '/2.0.0')
         self.assertEqual(comp_copy.wasDerivedFrom[0], comp.identity)
         self.assertEqual(comp_copy.types[0], sbol.constants.BIOPAX_DNA)

--- a/test/test_property.py
+++ b/test/test_property.py
@@ -21,7 +21,7 @@ class TestProperty(unittest.TestCase):
 
     def test_noListProperty(self):
         plasmid = sbol.ComponentDefinition('pBB1', sbol.BIOPAX_DNA, '1.0.0')
-        with self.assertRaises(TypeError):
+        with self.assertRaises(ValueError):
             plasmid.version = ['1', '2']
 
     def test_addPropertyToList(self):
@@ -246,7 +246,7 @@ class TestProperty(unittest.TestCase):
         r.start = 42
         self.assertEqual(type(r.start), int)
         self.assertEqual(r.start, 42)
-        with self.assertRaises(TypeError):
+        with self.assertRaises(ValueError):
             r.start = 'forty-two'
 
     def test_uri_property_list(self):

--- a/test/test_property.py
+++ b/test/test_property.py
@@ -108,7 +108,7 @@ class TestProperty(unittest.TestCase):
     def test_literal_property_properties(self):
         md = sbol.ModuleDefinition()
         self.assertNotIn(rdflib.URIRef(sbol.UNDEFINED), md.properties)
-        sbol.property.LiteralProperty(md, sbol.UNDEFINED, '0', '*', [], 'foo')
+        sbol.property.TextProperty(md, sbol.UNDEFINED, '0', '*', [], 'foo')
         # Creating the property should also create the entry in the
         # parent properties dict
         self.assertIn(rdflib.URIRef(sbol.UNDEFINED), md.properties)

--- a/test/test_property.py
+++ b/test/test_property.py
@@ -355,6 +355,29 @@ class TestIntProperty(unittest.TestCase):
         self.assertEqual(initial_value, prop.value)
         self.assertEqual([], prop._validation_rules)
 
+    def test_values(self):
+        # Cut class uses IntProperty
+        # Make sure we can set a IntProperty via a variety of types
+        # that can be coerced to float
+        cut = sbol2.Cut('m1')
+        self.assertEqual(0, cut.at)
+        # set with float
+        v = 2.54
+        cut.at = v
+        self.assertEqual(int(v), cut.at)
+        # set with string
+        v = '32'
+        cut.at = v
+        self.assertEqual(int(v), cut.at)
+        # set with string float
+        v = '1.37'
+        with self.assertRaises(ValueError):
+            cut.at = v
+        # set with int
+        v = 15
+        cut.at = v
+        self.assertEqual(int(v), cut.at)
+
 
 class TestTextProperty(unittest.TestCase):
 
@@ -404,6 +427,28 @@ class TestTextProperty(unittest.TestCase):
         prop = sbol2.TextProperty(cd, type_uri, '0', '1', None, initial_value)
         self.assertEqual(initial_value, prop.value)
         self.assertEqual([], prop._validation_rules)
+
+
+class TestFloatProperty(unittest.TestCase):
+
+    def test_values(self):
+        # Measurement class uses FloatProperty
+        # Make sure we can set a FloatProperty via a variety of types
+        # that can be coerced to float
+        m = sbol2.Measurement('m1')
+        self.assertEqual(0.0, m.value)
+        # set with float
+        v = 2.54
+        m.value = v
+        self.assertEqual(v, m.value)
+        # set with string
+        v = '1.37'
+        m.value = v
+        self.assertEqual(float(v), m.value)
+        # set with int
+        v = 15
+        m.value = v
+        self.assertEqual(float(v), m.value)
 
 
 if __name__ == '__main__':

--- a/test/test_provo.py
+++ b/test/test_provo.py
@@ -1,6 +1,10 @@
+import datetime
 import unittest
 
+import dateutil.parser
+
 import sbol2
+from sbol2 import Activity
 
 
 class TestProvo(unittest.TestCase):
@@ -42,3 +46,32 @@ class TestUsage(unittest.TestCase):
         self.assertEqual([sbol2.SO_PROMOTER, sbol2.SO_MISC, sbol2.SO_CDS], usage.roles)
         usage.removeRole(1)
         self.assertEqual([sbol2.SO_PROMOTER, sbol2.SO_CDS], usage.roles)
+
+
+class TestActivity(unittest.TestCase):
+
+    def test_started_at_time(self):
+        activity = Activity('activity1')
+        self.assertIsNone(activity.startedAtTime)
+        # Test setting via datetime.datetime
+        my_start = datetime.datetime.now()
+        activity.startedAtTime = my_start
+        self.assertEqual(my_start, activity.startedAtTime)
+        # Test setting via string
+        start_string = '2016-03-16T20:12:00Z'
+        activity.startedAtTime = start_string
+        start_dt = dateutil.parser.parse(start_string)
+        self.assertEqual(start_dt, activity.startedAtTime)
+
+    def test_ended_at_time(self):
+        activity = Activity('activity2')
+        self.assertIsNone(activity.endedAtTime)
+        # Test setting via datetime.datetime
+        my_end = datetime.datetime.now()
+        activity.endedAtTime = my_end
+        self.assertEqual(my_end, activity.endedAtTime)
+        # Test setting via string
+        end_string = '2016-03-16T20:12:00Z'
+        activity.endedAtTime = end_string
+        end_dt = dateutil.parser.parse(end_string)
+        self.assertEqual(end_dt, activity.endedAtTime)

--- a/test/test_versionproperty.py
+++ b/test/test_versionproperty.py
@@ -1,0 +1,28 @@
+import unittest
+
+import sbol2
+
+
+class TestVersionProperty(unittest.TestCase):
+
+    def test_values(self):
+        cd = sbol2.ComponentDefinition('cd1')
+        self.assertEqual('1', cd.version)
+        with self.assertRaises(ValueError):
+            cd.version = 'tom'
+        with self.assertRaises(ValueError):
+            # Floats are not acceptable, must be a string
+            cd.version = 1.2
+        v = '2'
+        cd.version = v
+        self.assertEqual(v, cd.version)
+        v = '2.3'
+        cd.version = v
+        self.assertEqual(v, cd.version)
+        v = '2.3.1'
+        cd.version = v
+        self.assertEqual(v, cd.version)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Change all remaining uses of `LiteralProperty` to a more appropriate subclass like `TextProperty`, `IntProperty`, `FloatProperty`, `DateTimeProperty`, or `VersionProperty`.

Additionally make most or all of these classes raise `ValueError` if the value passed is inappropriate for the expected type. An effort is made to accept other types, like `str` for `int`, for example.
