### PR TITLE
Ensure properties initialize parent's value store

### DIFF
--- a/sbol2/__init__.py
+++ b/sbol2/__init__.py
@@ -30,9 +30,9 @@ from .moduledefinition import ModuleDefinition
 from .object import SBOLObject
 from .participation import Participation
 from .partshop import PartShop
-from .property import IntProperty
-from .property import LiteralProperty
-from .property import TextProperty
+from .property import DateTimeProperty, FloatProperty, IntProperty
+from .property import LiteralProperty, OwnedObject
+from .property import ReferencedObject, TextProperty
 from .property import URIProperty
 from .provo import Activity
 from .provo import Agent
@@ -45,3 +45,4 @@ from .sequenceannotation import SequenceAnnotation
 from .toplevel import TopLevel
 from .validation import is_alphanumeric_or_underscore
 from .validation import is_not_alphanumeric_or_underscore
+from .versionproperty import VersionProperty

--- a/test/test_ownedobject.py
+++ b/test/test_ownedobject.py
@@ -150,3 +150,13 @@ class TestOwnedObject(unittest.TestCase):
         doc.componentDefinitions.remove(cd.persistentIdentity)
         self.assertNotIn(cd.persistentIdentity, doc.componentDefinitions)
         self.assertNotIn(cd.identity, doc.SBOLObjects)
+
+    def test_init_store(self):
+        # Ensure that property constructors initialize the parent
+        # object's value store
+        obj = sbol2.SBOLObject()
+        type_uri = 'http://example.com#thing'
+        obj.thing = sbol2.OwnedObject(obj, type_uri, int, '0', '*')
+        self.assertIn(type_uri, obj.owned_objects)
+        self.assertEqual([], obj.owned_objects[type_uri])
+        self.assertEqual([], obj.thing.value)

--- a/test/test_property.py
+++ b/test/test_property.py
@@ -1,3 +1,4 @@
+import datetime
 import unittest
 import os
 
@@ -378,6 +379,16 @@ class TestIntProperty(unittest.TestCase):
         cut.at = v
         self.assertEqual(int(v), cut.at)
 
+    def test_init_store(self):
+        # Ensure that property constructors initialize the parent
+        # object's value store
+        obj = sbol2.SBOLObject()
+        type_uri = 'http://example.com#thing'
+        obj.thing = sbol2.IntProperty(obj, type_uri, '0', '*')
+        self.assertIn(type_uri, obj.properties)
+        self.assertEqual([], obj.properties[type_uri])
+        self.assertEqual([], obj.thing)
+
 
 class TestTextProperty(unittest.TestCase):
 
@@ -428,6 +439,16 @@ class TestTextProperty(unittest.TestCase):
         self.assertEqual(initial_value, prop.value)
         self.assertEqual([], prop._validation_rules)
 
+    def test_init_store(self):
+        # Ensure that property constructors initialize the parent
+        # object's value store
+        obj = sbol2.SBOLObject()
+        type_uri = 'http://example.com#thing'
+        obj.thing = sbol2.TextProperty(obj, type_uri, '0', '*')
+        self.assertIn(type_uri, obj.properties)
+        self.assertEqual([], obj.properties[type_uri])
+        self.assertEqual([], obj.thing)
+
 
 class TestFloatProperty(unittest.TestCase):
 
@@ -449,6 +470,77 @@ class TestFloatProperty(unittest.TestCase):
         v = 15
         m.value = v
         self.assertEqual(float(v), m.value)
+
+    def test_init_store(self):
+        # Ensure that property constructors initialize the parent
+        # object's value store
+        obj = sbol2.SBOLObject()
+        type_uri = 'http://example.com#thing'
+        obj.thing = sbol2.FloatProperty(obj, type_uri, '0', '*')
+        self.assertIn(type_uri, obj.properties)
+        self.assertEqual([], obj.properties[type_uri])
+        self.assertEqual([], obj.thing)
+
+
+class TestDateTimeProperty(unittest.TestCase):
+
+    def test_values(self):
+        # Activity class uses DateTimeProperty
+        # Make sure we can set a DateTimeProperty via a variety of formats
+        # that can be parsed by dateutil
+        activity = sbol2.Activity('a1')
+        self.assertIsNone(activity.startedAtTime)
+        # set with datetime
+        v = datetime.datetime.now()
+        activity.startedAtTime = v
+        self.assertEqual(v, activity.startedAtTime)
+        # set with string
+        dt = datetime.datetime.now()
+        v = str(dt)
+        activity.startedAtTime = v
+        self.assertEqual(dt, activity.startedAtTime)
+        # set with string in ISO format
+        dt = datetime.datetime.now()
+        v = dt.isoformat()
+        activity.startedAtTime = v
+        self.assertEqual(dt, activity.startedAtTime)
+
+    def test_init_store(self):
+        # Ensure that property constructors initialize the parent
+        # object's value store
+        obj = sbol2.SBOLObject()
+        type_uri = 'http://example.com#thing'
+        obj.thing = sbol2.DateTimeProperty(obj, type_uri, '0', '*')
+        self.assertIn(type_uri, obj.properties)
+        self.assertEqual([], obj.properties[type_uri])
+        self.assertEqual([], obj.thing)
+
+
+class TestReferencedObject(unittest.TestCase):
+
+    def test_init_store(self):
+        # Ensure that property constructors initialize the parent
+        # object's value store
+        obj = sbol2.SBOLObject()
+        type_uri = 'http://example.com#thing'
+        ref_uri = 'http://example.com#other_thing'
+        obj.thing = sbol2.ReferencedObject(obj, type_uri, ref_uri, '0', '*', [])
+        self.assertIn(type_uri, obj.properties)
+        self.assertEqual([], obj.properties[type_uri])
+        self.assertEqual([], obj.thing)
+
+
+class TestURIProperty(unittest.TestCase):
+
+    def test_init_store(self):
+        # Ensure that property constructors initialize the parent
+        # object's value store
+        obj = sbol2.SBOLObject()
+        type_uri = 'http://example.com#thing'
+        obj.thing = sbol2.URIProperty(obj, type_uri, '0', '*', [])
+        self.assertIn(type_uri, obj.properties)
+        self.assertEqual([], obj.properties[type_uri])
+        self.assertEqual([], obj.thing)
 
 
 if __name__ == '__main__':

--- a/test/test_versionproperty.py
+++ b/test/test_versionproperty.py
@@ -23,6 +23,16 @@ class TestVersionProperty(unittest.TestCase):
         cd.version = v
         self.assertEqual(v, cd.version)
 
+    def test_init_store(self):
+        # Ensure that property constructors initialize the parent
+        # object's value store
+        obj = sbol2.SBOLObject()
+        type_uri = 'http://example.com#thing'
+        obj.thing = sbol2.VersionProperty(obj, type_uri, '0', '*')
+        self.assertIn(type_uri, obj.properties)
+        self.assertEqual([], obj.properties[type_uri])
+        self.assertEqual([], obj.thing)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Add tests to ensure all properties initialize the parent value store
on construction. All properties already initialized the parent store
so no modifications to the properties themselves were necessary.

Fixes #52 