### PR TITLE
Add optional validation to Document.write()

### DIFF
--- a/dev/hooks/pre-commit
+++ b/dev/hooks/pre-commit
@@ -16,7 +16,7 @@ fi
 # Run style checker
 MAX_VIOLATIONS=23
 echo "Checking style..."
-pycodestyle sbol2 test > style.txt
+pycodestyle sbol2 test examples > style.txt
 result=$(cat style.txt | wc -l)
 if [ "$result" -gt $MAX_VIOLATIONS ]; then
     cat <<EOF

--- a/sbol2/document.py
+++ b/sbol2/document.py
@@ -2,6 +2,7 @@ import collections.abc
 import logging
 import os
 import posixpath
+import time
 from typing import Any, Dict, Mapping, Union
 import warnings
 
@@ -395,6 +396,16 @@ class Document(Identified):
         or empty string if validation is disabled.
         """
         self.doc_serialize_rdf2xml(filename)
+        # Optionally validate
+        result = 'Validation disabled. To enable use of the online validation tool, use'
+        result += ' Config.setOption(ConfigOptions.VALIDATE, True)'
+        if Config.getOption(ConfigOptions.VALIDATE):
+            t_start = time.time()
+            result = self.validate()
+            if Config.getOption(ConfigOptions.VERBOSE):
+                t_end = time.time()
+                print(f'Validation request took {t_end - t_start} seconds')
+        return result
 
     def read(self, filename):
         """

--- a/test/test_roundtrip.py
+++ b/test/test_roundtrip.py
@@ -19,6 +19,9 @@ class TestRoundTripSBOL2(unittest.TestCase):
     def setUp(self):
         # Create temp directory
         self.temp_out_dir = tempfile.mkdtemp()
+        # Disable validation to avoid unnecessary round trips
+        # to the online validator
+        sbol2.Config.setOption(sbol2.ConfigOptions.VALIDATE, False)
         self.logger = logging.getLogger('sbol2.test')
         if not self.logger.hasHandlers():
             logging.basicConfig()

--- a/test/test_sequence.py
+++ b/test/test_sequence.py
@@ -1,11 +1,8 @@
 import os
-import sys
 import tempfile
 import unittest
 
-import rdflib
-
-import sbol2 as sbol
+import sbol2
 
 MODULE_LOCATION = os.path.dirname(os.path.abspath(__file__))
 CRISPR_EXAMPLE = os.path.join(MODULE_LOCATION, 'resources', 'crispr_example.xml')
@@ -14,23 +11,23 @@ CRISPR_EXAMPLE = os.path.join(MODULE_LOCATION, 'resources', 'crispr_example.xml'
 class TestSequence(unittest.TestCase):
 
     def testAddSequence(self):
-        test_seq = sbol.Sequence("R0010", "ggctgca")
-        doc = sbol.Document()
+        test_seq = sbol2.Sequence("R0010", "ggctgca")
+        doc = sbol2.Document()
         doc.addSequence(test_seq)
         seq = doc.sequences.get("R0010").elements
 
         self.assertEqual(seq, 'ggctgca')
 
     def testRemoveSequence(self):
-        test_seq = sbol.Sequence("R0010", "ggctgca")
-        doc = sbol.Document()
+        test_seq = sbol2.Sequence("R0010", "ggctgca")
+        doc = sbol2.Document()
         doc.addSequence(test_seq)
         doc.sequences.remove(0)
-        with self.assertRaises(sbol.SBOLError):
+        with self.assertRaises(sbol2.SBOLError):
             doc.sequences.get("R0010")
 
     def testSeqDisplayId(self):
-        doc = sbol.Document()
+        doc = sbol2.Document()
         doc.read(CRISPR_EXAMPLE)
 
         # List of displayIds
@@ -41,15 +38,15 @@ class TestSequence(unittest.TestCase):
         self.assertCountEqual(listseq_read, listseq)
 
     def testSequenceEncoding(self):
-        doc = sbol.Document()
+        doc = sbol2.Document()
         doc.read(CRISPR_EXAMPLE)
         seq = doc.sequences.get('CRP_b_seq')
-        self.assertEqual(seq.encoding, sbol.SBOL_ENCODING_IUPAC)
+        self.assertEqual(seq.encoding, sbol2.SBOL_ENCODING_IUPAC)
 
     def testSequenceElement(self):
-        sbol.setHomespace('http://sbols.org/CRISPR_Example')
-        sbol.Config.setOption('sbol_typed_uris', False)
-        doc = sbol.Document()
+        sbol2.setHomespace('http://sbols.org/CRISPR_Example')
+        sbol2.Config.setOption('sbol_typed_uris', False)
+        doc = sbol2.Document()
         doc.read(CRISPR_EXAMPLE)
         # Sequence to test against
         seq = ('GCTCCGAATTTCTCGACAGATCTCATGTGATTACGCCAAGCTACGGGCGGAGTACTGTCCTC'
@@ -62,9 +59,9 @@ class TestSequence(unittest.TestCase):
         self.assertEqual(seq_read, seq)
 
     def testUpdateSequenceElement(self):
-        sbol.setHomespace('http://sbols.org/CRISPR_Example')
-        sbol.Config.setOption('sbol_typed_uris', False)
-        doc = sbol.Document()
+        sbol2.setHomespace('http://sbols.org/CRISPR_Example')
+        sbol2.Config.setOption('sbol_typed_uris', False)
+        doc = sbol2.Document()
         doc.read(CRISPR_EXAMPLE)
         # Sequence to test against
         seq = 'AAAAA'
@@ -74,14 +71,14 @@ class TestSequence(unittest.TestCase):
 
     # File I/O Tests
     def testUpdateWrite(self):
-        sbol.setHomespace('http://sbols.org/CRISPR_Example')
-        sbol.Config.setOption('sbol_typed_uris', False)
-        doc = sbol.Document()
+        sbol2.setHomespace('http://sbols.org/CRISPR_Example')
+        sbol2.Config.setOption('sbol_typed_uris', False)
+        doc = sbol2.Document()
         doc.read(CRISPR_EXAMPLE)
         # Sequence to test against
         seq = 'AAAAA'
         doc.sequences.get('CRP_b_seq').elements = seq
-        doc2 = sbol.Document()  # Document to compare for equality
+        doc2 = sbol2.Document()  # Document to compare for equality
         with tempfile.TemporaryDirectory() as tmpdirname:
             test_file = os.path.join(tmpdirname, 'test.xml')
             # Write to disk
@@ -92,5 +89,5 @@ class TestSequence(unittest.TestCase):
         self.assertEqual(seq_read, seq)
 
     def test_bool(self):
-        seq = sbol.Sequence()
+        seq = sbol2.Sequence()
         self.assertTrue(seq)


### PR DESCRIPTION
Add a unit test for the various Document.write() cases, including verbosity. Throw in a few style improvements as well, while we were nearby.

Fixes #205 