### PR TITLE
Drop Python 2 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ from setuptools import setup
 setup(name='sbol2',
       version='1.0b7',
       description='Pure Python implementation of SBOL 2 standard',
+      python_requires='>=3.4',
       url='https://github.com/SynBioDex/pySBOL2',
       author='Bryan Bartley',
       author_email='editors@sbolstandard.org',

--- a/test/test_componentdefinition.py
+++ b/test/test_componentdefinition.py
@@ -1,5 +1,4 @@
 import os
-import sys
 import unittest
 import rdflib
 import sbol2
@@ -75,12 +74,7 @@ class TestComponentDefinitions(unittest.TestCase):
         primary_sequence = gene.getPrimaryStructure()
         for component in primary_sequence:
             list_cd.append(component.displayId)
-
-        # Python 3 compatability
-        if sys.version_info[0] < 3:
-            self.assertItemsEqual(list_cd, list_cd_true)
-        else:
-            self.assertCountEqual(list_cd, list_cd_true)
+        self.assertCountEqual(list_cd, list_cd_true)
 
     def testInsertDownstream(self):
         doc = sbol2.Document()

--- a/test/test_style.py
+++ b/test/test_style.py
@@ -16,6 +16,7 @@ MODULE_LOCATION = os.path.dirname(os.path.abspath(__file__))
 SBOL_PATH = os.path.join(os.path.dirname(MODULE_LOCATION), 'sbol2')
 TEST_PATH = MODULE_LOCATION
 EXAMPLES_PATH = os.path.join(os.path.dirname(MODULE_LOCATION), 'examples')
+SETUP_PATH = os.path.join(os.path.dirname(MODULE_LOCATION), 'setup.py')
 STYLE_CONFIG = os.path.join(os.path.dirname(MODULE_LOCATION), 'setup.cfg')
 
 # Please don't increase this number!
@@ -71,6 +72,7 @@ class TestStyle(unittest.TestCase):
         style.input_dir(SBOL_PATH)
         style.input_dir(TEST_PATH)
         style.input_dir(EXAMPLES_PATH)
+        style.input_file(SETUP_PATH)
         style.options.report.stop()
         result = style.options.report
         # Please try not to increase the expected number of errors. Please.


### PR DESCRIPTION
Drop support for Python 2 entirely. The code was already incompatible, and Python 2 is beyond its end of life.

Require Python 3 for installation via the `python_requires` argument in setup.py.

Fixes #16 
