### PR TITLE
Check for duplicate URIs

### DIFF
--- a/sbol2/property.py
+++ b/sbol2/property.py
@@ -593,6 +593,14 @@ class OwnedObject(Property):
         # Update URI for the argument object and all its children,
         # if SBOL-compliance is enabled.
         sbol_obj.update_uri()
+        # Check that this URI is unique within the object store
+        # See issue #127
+        for obj in object_store:
+            if obj.identity == sbol_obj.identity:
+                raise SBOLError("The object " + sbol_obj.identity +
+                                " is already contained by the " +
+                                self._rdf_type + " property",
+                                SBOLErrorCode.SBOL_ERROR_URI_NOT_UNIQUE)
         # Add to parent object
         object_store.append(sbol_obj)
         # Run validation rules

--- a/test/test_ownedobject.py
+++ b/test/test_ownedobject.py
@@ -160,3 +160,26 @@ class TestOwnedObject(unittest.TestCase):
         self.assertIn(type_uri, obj.owned_objects)
         self.assertEqual([], obj.owned_objects[type_uri])
         self.assertEqual([], obj.thing.value)
+
+    def test_duplicate_uri_no_doc(self):
+        cd = sbol2.ComponentDefinition('cd')
+        cd.sequenceAnnotations.create('sa')
+        with self.assertRaises(sbol2.SBOLError) as cm:
+            cd.sequenceAnnotations.create('sa')
+        raised = cm.exception
+        self.assertEqual(raised.error_code(),
+                         sbol2.SBOLErrorCode.SBOL_ERROR_URI_NOT_UNIQUE)
+
+    def test_duplicate_uri_in_doc(self):
+        doc = sbol2.Document()
+        cd = doc.componentDefinitions.create('cd')
+        cd.sequenceAnnotations.create('sa')
+        with self.assertRaises(sbol2.SBOLError) as cm:
+            cd.sequenceAnnotations.create('sa')
+        raised = cm.exception
+        self.assertEqual(raised.error_code(),
+                         sbol2.SBOLErrorCode.SBOL_ERROR_URI_NOT_UNIQUE)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_property.py
+++ b/test/test_property.py
@@ -176,8 +176,8 @@ class TestProperty(unittest.TestCase):
         cd.annotations = sbol.property.OwnedObject(cd, annotation_uri, sbol.Identified,
                                                    '0', '*', None)
         self.assertEqual(type(cd.annotations), sbol.property.OwnedObject)
-        cd.annotations.add(sbol.Identified('foo_0'))
-        cd.annotations.add(sbol.Identified('foo_1'))
+        cd.annotations.add(sbol.Identified(uri='foo_0'))
+        cd.annotations.add(sbol.Identified(uri='foo_1'))
         self.assertEqual(type(cd.annotations), sbol.property.OwnedObject)
 
     def test_owned_object_find(self):


### PR DESCRIPTION
When adding OwnedObjects check for duplicate URIs so that whether inside
or outside a document, no duplicate URIs can exist.

Fixes #127 