### PR TITLE
Always use `type_uri` in constructors

### DIFF
--- a/sbol2/component.py
+++ b/sbol2/component.py
@@ -9,8 +9,8 @@ from .property import URIProperty, OwnedObject, ReferencedObject
 
 
 class ComponentInstance(Identified):
-    def __init__(self, rdf_type, uri, definition, access, version):
-        super().__init__(rdf_type, uri, version)
+    def __init__(self, type_uri, uri, definition, access, version):
+        super().__init__(type_uri, uri, version)
         self.definition = ReferencedObject(self, SBOL_DEFINITION,
                                            SBOL_COMPONENT_DEFINITION,
                                            '1', '1', [], definition)

--- a/sbol2/componentdefinition.py
+++ b/sbol2/componentdefinition.py
@@ -100,7 +100,7 @@ class ComponentDefinition(TopLevel):
     def __init__(self, uri=URIRef("example"),
                  component_type=URIRef(BIOPAX_DNA),
                  version=VERSION_STRING,
-                 rdf_type=SBOL_COMPONENT_DEFINITION):
+                 type_uri=SBOL_COMPONENT_DEFINITION):
         """Construct a ComponentDefinition.
 
         :param uri: A full URI including a scheme, namespace, and identifier.
@@ -113,10 +113,10 @@ class ComponentDefinition(TopLevel):
         :param version: An arbitrary version string.
         If SBOLCompliance is enabled, this should be a Maven version string
         of the form "major.minor.patch".
-        :param rdf_type: The RDF type for an extension class
+        :param type_uri: The RDF type for an extension class
         derived from this one
         """
-        super().__init__(rdf_type, uri, version)
+        super().__init__(type_uri, uri, version)
         self.types = URIProperty(self, SBOL_TYPES,
                                  '1', '*', None, component_type)
         self.roles = URIProperty(self, SBOL_ROLES,

--- a/sbol2/model.py
+++ b/sbol2/model.py
@@ -6,10 +6,10 @@ from .constants import *
 
 
 class Model(TopLevel):
-    def __init__(self, rdf_type=SBOL_MODEL, uri=URIRef('example'), source='',
+    def __init__(self, type_uri=SBOL_MODEL, uri=URIRef('example'), source='',
                  language=EDAM_SBML, framework=SBO_CONTINUOUS,
                  version=VERSION_STRING):
-        super().__init__(rdf_type, uri, version)
+        super().__init__(type_uri, uri, version)
         self.source = URIProperty(self, SBOL_SOURCE,
                                   '0', '1', [], source)
         self.language = URIProperty(self, SBOL_LANGUAGE,

--- a/sbol2/module.py
+++ b/sbol2/module.py
@@ -9,8 +9,8 @@ class Module(Identified):
     def __init__(self, uri='example',
                  # Everything after the asterisk (`*`) is a keyword
                  *, definition='', version=VERSION_STRING,
-                 rdf_type=SBOL_MODULE):
-        super().__init__(rdf_type, uri, version)
+                 type_uri=SBOL_MODULE):
+        super().__init__(type_uri, uri, version)
         self.definition = ReferencedObject(self, SBOL_DEFINITION,
                                            SBOL_MODULE_DEFINITION,
                                            '1', '1', [], definition)

--- a/sbol2/moduledefinition.py
+++ b/sbol2/moduledefinition.py
@@ -78,7 +78,7 @@ class ModuleDefinition(TopLevel):
     models = None
 
     def __init__(self, uri=rdflib.URIRef("example"), version=VERSION_STRING,
-                 sbol_type_uri=SBOL_MODULE_DEFINITION):
+                 type_uri=SBOL_MODULE_DEFINITION):
         """Construct a ModuleDefinition
 
         :param uri: A full URI including a scheme, namespace, and identifier.
@@ -87,10 +87,10 @@ class ModuleDefinition(TopLevel):
         for the new object and a full URI will automatically be constructed.
         :param version: An arbitrary version string. If SBOLCompliance is enabled,
         this should be a valid [Maven version string](http://maven.apache.org/).
-        :param sbol_type_uri: The RDF type for an extension class
+        :param type_uri: The RDF type for an extension class
         derived from this one (optional)
         """
-        super().__init__(sbol_type_uri, uri, version)
+        super().__init__(type_uri, uri, version)
         self.roles = URIProperty(self, SBOL_ROLES, '0', '*', None)
         self.models = ReferencedObject(self, SBOL_MODELS,
                                        SBOL_MODEL, '0', '*', [])

--- a/sbol2/provo.py
+++ b/sbol2/provo.py
@@ -24,7 +24,7 @@ class Association(Identified):
 
     def __init__(self, uri=URIRef("example"), agent=None,
                  role=None, version=VERSION_STRING,
-                 rdf_type=PROVO_ASSOCIATION):
+                 type_uri=PROVO_ASSOCIATION):
         """Constructor.
 
         :param uri: A full URI including a scheme, namespace, and identifier.
@@ -34,10 +34,10 @@ class Association(Identified):
         :param agent:
         :param role:
         :param version:
-        :param rdf_type: The RDF type for an extension class
+        :param type_uri: The RDF type for an extension class
         derived from this one.
         """
-        super().__init__(rdf_type, uri, version)
+        super().__init__(type_uri, uri, version)
         self.agent = ReferencedObject(self, PROVO_AGENT_PROPERTY, PROVO_AGENT,
                                       '1', '1', [], agent)
         self.roles = URIProperty(self, PROVO_HAD_ROLE, '1', '*', [], role)
@@ -67,7 +67,7 @@ class Usage(Identified):
 
     def __init__(self, uri=URIRef("example"), entity=None,
                  role=None, version=VERSION_STRING,
-                 rdf_type=PROVO_USAGE):
+                 type_uri=PROVO_USAGE):
         """Constructor.
 
         :param uri: A full URI including a scheme, namespace, and identifier.
@@ -79,7 +79,7 @@ class Usage(Identified):
         :param version:
         :param type: The RDF type for an extension class derived from this one.
         """
-        super().__init__(rdf_type, uri, version)
+        super().__init__(type_uri, uri, version)
         self.entity = URIProperty(self, PROVO_ENTITY, '1', '1', [], entity)
         self.roles = URIProperty(self, PROVO_HAD_ROLE, '1', '*', [], role)
 
@@ -100,7 +100,7 @@ class Agent(TopLevel):
     such as software version needed to be able to run the same software again.
     """
     def __init__(self, uri=URIRef("example"), version=VERSION_STRING,
-                 rdf_type=PROVO_AGENT):
+                 type_uri=PROVO_AGENT):
         """Constructor.
 
         :param uri: A full URI including a scheme, namespace, and identifier.
@@ -109,12 +109,12 @@ class Agent(TopLevel):
         and a full URI will automatically be constructed.
         :param version:
         """
-        super().__init__(rdf_type, uri, version)
+        super().__init__(type_uri, uri, version)
 
 
 class Plan(TopLevel):
     def __init__(self, uri=URIRef("example"), version=VERSION_STRING,
-                 rdf_type=PROVO_PLAN):
+                 type_uri=PROVO_PLAN):
         """Constructor.
 
         :param uri: A full URI including a scheme, namespace, and identifier.
@@ -123,7 +123,7 @@ class Plan(TopLevel):
         and a full URI will automatically be constructed.
         :param version:
         """
-        super().__init__(rdf_type, uri, version)
+        super().__init__(type_uri, uri, version)
 
 
 class Activity(TopLevel):
@@ -168,7 +168,7 @@ class Activity(TopLevel):
     plan = None
 
     def __init__(self, uri=URIRef("example"), action_type="",
-                 version=VERSION_STRING, rdf_type=PROVO_ACTIVITY):
+                 version=VERSION_STRING, type_uri=PROVO_ACTIVITY):
         """Constructor
 
         :param uri: A full URI including a scheme, namespace, and identifier.
@@ -177,10 +177,10 @@ class Activity(TopLevel):
         and a full URI will automatically be constructed.
         :param action_type:
         :param version:
-        :param rdf_type: The RDF type for an extension class
+        :param type_uri: The RDF type for an extension class
         derived from this one.
         """
-        super().__init__(rdf_type, uri, version)
+        super().__init__(type_uri, uri, version)
         self.plan = OwnedObject(self, PROVO_PLAN, Plan,
                                 '0', '1', [validation.libsbol_rule_22])
         self.agent = ReferencedObject(self, PROVO_AGENT, Agent,


### PR DESCRIPTION
Change uses of `rdf_type` as a constructor keyword to use `type_uri` so that
all constructors are the same. This should reduce confusion between the
keyword arguments that mean the same thing but are spelled differently.

Fixes #315 