### PR TITLE
Add PartShop.searchCount

### DIFF
--- a/docs/repositories.rst
+++ b/docs/repositories.rst
@@ -59,7 +59,7 @@ Searching Part Repos
 
 PySBOL2 supports three kinds of searches: a **general search**, an **exact search**, and an **advanced search**.
 
-The following query conducts a **general search** which scans through `identity`, `name`, `description`, and `displayId` properties for a match to the search text, including partial, case-insensitive matches to substrings of the property value. Search results are returned as a `SearchResponse` object.
+The following query conducts a **general search** which scans through `identity`, `name`, `description`, and `displayId` properties for a match to the search text, including partial, case-insensitive matches to substrings of the property value. Search results are returned as a list.
 
 .. code:: python
 
@@ -79,7 +79,7 @@ Of course, these parameters can be changed to search for different type of SBOL 
 
     import time
 
-    records = SearchResponse()
+    records = []
     search_term = 'plasmid'
     limit = 25
     total_hits = igem.searchCount(search_term)
@@ -88,14 +88,14 @@ Of course, these parameters can be changed to search for different type of SBOL 
         time.sleep(0.1)
 .. end
 
-A ``SearchResponse`` object is returned by a query and contains multiple records. Each record contains basic data, including identity, displayId, name, and description fields. *It is very important to realize however that the search does not retrieve the complete ComponentDefinition!* In order to retrieve the full object, the user must call ``pull`` while specifying the target object's identity.
+The list returned by ``search`` contains multiple records. Each record contains basic data, including identity, displayId, name, and description fields. *It is very important to realize however that the search does not retrieve the complete ComponentDefinition!* In order to retrieve the full object, the user must call ``pull`` while specifying the target object's identity.
 
-Records in a ``SearchResponse`` can be accessed using iterators or numeric indices. The interface for each record behaves exactly like any other SBOL object:
+Records returned by ``search`` have an ``identity`` attribute that can be used when calling ``pull``:
 
 .. code:: python
 
     for record in records:
-        print( record.identity.get() )
+        print(record.identity)
 .. end
 
 The preceding examples concern **general searches**, which scan through an object's metadata for partial matches to the search term. In contrast, the **exact search** explicitly specifies which property of an object to search, and the value of that property must exactly match the search term. The following **exact search** will search for ``ComponentDefinitions`` with a role of promoter:
@@ -104,6 +104,9 @@ The preceding examples concern **general searches**, which scan through an objec
 
     records = igem.search(SO_PROMOTER, SBOL_COMPONENT_DEFINITION, SBOL_ROLES, 0, 25);
 .. end
+
+*Note: advanced search is not yet implemented in pySBOL2.*
+*This documentation describes how it works in pySBOL.*
 
 Finally, the **advanced search** allows the user to configure a search with multiple criteria by constructing a ``SearchQuery`` object. The following query looks for promoters that have an additional annotation indicating that the promoter is regulated (as opposed to constitutive):
 

--- a/examples/search.py
+++ b/examples/search.py
@@ -12,7 +12,6 @@ total_hits = igem.searchCount(search_term)
 print(f'Expecting {total_hits} records')
 for offset in range(0, total_hits, limit):
     records.extend(igem.search(search_term, sbol2.SBOL_COMPONENT_DEFINITION,
-                               None,
                                offset, limit))
     time.sleep(0.1)
 print(f'Received {len(records)} records')

--- a/examples/search.py
+++ b/examples/search.py
@@ -1,0 +1,18 @@
+import time
+import sbol2
+
+# This example is from the documentation at
+# https://pysbol.readthedocs.io/en/latest/repositories.html
+
+igem = sbol2.PartShop('https://synbiohub.org/public/igem')
+records = []
+search_term = 'plasmid'
+limit = 25
+total_hits = igem.searchCount(search_term)
+print(f'Expecting {total_hits} records')
+for offset in range(0, total_hits, limit):
+    records.extend(igem.search(search_term, sbol2.SBOL_COMPONENT_DEFINITION,
+                               None,
+                               offset, limit))
+    time.sleep(0.1)
+print(f'Received {len(records)} records')

--- a/sbol2/partshop.py
+++ b/sbol2/partshop.py
@@ -398,3 +398,35 @@ class PartShop:
         # property_uri is specified, do an exact search
         return self.search_exact(search_text, object_type, property_uri,
                                  offset, limit)
+
+    def _search_count(self, search_text, object_type, property_uri):
+        search_url = parseURLDomain(self.resource)
+        query = dict(objectType=parseClassName(object_type))
+        query = urllib.parse.urlencode(query)
+        search_text = urllib.parse.quote(search_text)
+        # params = dict(offset=offset, limit=limit)
+        # params = urllib.parse.urlencode(params)
+        # query_url = f'{search_url}/search/{query}&{search_text}/?{params}'
+        url = f'{search_url}/searchCount/{query}&{search_text}/'
+        headers = {'Accept': 'text/plain'}
+        if self.key:
+            headers['X-authorization'] = self.key
+        self.logger.info('searchCount query: %s', url)
+        response = requests.get(url, headers=headers)
+        if not response:
+            # Something went wrong
+            raise SBOLError(response, SBOLErrorCode.SBOL_ERROR_BAD_HTTP_REQUEST)
+        # Everything looks good, parse and return the results
+        return int(response.text)
+
+    def searchCount(self, search_text, object_type=None, property_uri=None):
+        """Returns the number of records matching the given criteria.
+        """
+        # if search_text is a SearchQuery, dispatch to ???
+
+        # if object_type is not specified, default to SBOL_COMPONENT_DEFINITION
+        if object_type is None:
+            object_type = SBOL_COMPONENT_DEFINITION
+
+        # Dispatch to the internal search count method
+        return self._search_count(search_text, object_type, property_uri)

--- a/sbol2/partshop.py
+++ b/sbol2/partshop.py
@@ -3,7 +3,7 @@ import http
 import logging
 import os
 import posixpath
-from typing import List, Optional
+from typing import List, Optional, Union
 import urllib.parse
 
 import requests
@@ -17,6 +17,11 @@ from .constants import *
 from .sbolerror import SBOLError
 from .sbolerror import SBOLErrorCode
 from .identified import Identified
+
+
+class SearchQuery:
+    """This is a stub until SearchQuery is implemented."""
+    pass
 
 
 class PartShop:
@@ -387,10 +392,17 @@ class PartShop:
 
     def search(self, search_text: str,
                object_type: Optional[str] = SBOL_COMPONENT_DEFINITION,
-               property_uri: Optional[str] = None,
+               property_uri: Optional[Union[str, int]] = None,
                offset: int = 0, limit: int = 25) -> List[Identified]:
         # if search_text is a SearchQuery, dispatch to search_advanced
-
+        if type(search_text) is SearchQuery:
+            raise NotImplementedError('search using SearchQuery is not implemented')
+        if type(property_uri) is int:
+            # User called without property_uri and with offset. Shift args
+            if offset > 0:
+                limit = offset
+            offset = property_uri
+            property_uri = None
         # if property_uri is not specified, do a general search
         if property_uri is None:
             return self.search_general(search_text, object_type, offset,
@@ -423,6 +435,8 @@ class PartShop:
         """Returns the number of records matching the given criteria.
         """
         # if search_text is a SearchQuery, dispatch to ???
+        if type(search_text) is SearchQuery:
+            raise NotImplementedError('search using SearchQuery is not implemented')
 
         # if object_type is not specified, default to SBOL_COMPONENT_DEFINITION
         if object_type is None:

--- a/test/test_partshop.py
+++ b/test/test_partshop.py
@@ -239,6 +239,23 @@ WHERE {
         self.assertTrue(all([isinstance(x, sbol2.Identified)
                              for x in results]))
 
+    def test_search_general_offset_limit(self):
+        # Test a general search using offset and limit
+        # This comes from a documentation example that was failing
+        sbh = sbol2.PartShop(TEST_RESOURCE)
+        offset = 10
+        limit = 20
+        results = sbh.search('plasmid', sbol2.SBOL_COMPONENT_DEFINITION,
+                             offset, limit)
+        # The response is a list
+        self.assertEqual(list, type(results))
+        # There are `limit` items in the list (search returns more,
+        # but by default we get the first `limit`)
+        self.assertEqual(limit, len(results))
+        # The response items are all of type Identified
+        self.assertTrue(all([isinstance(x, sbol2.Identified)
+                             for x in results]))
+
     def test_search_exact(self):
         igem = sbol.PartShop('https://synbiohub.org')
         limit = 10

--- a/test/test_partshop.py
+++ b/test/test_partshop.py
@@ -270,6 +270,16 @@ WHERE {
         self.assertIsNotNone(doc.version)
         self.assertEqual(old_version, doc.version)
 
+    def test_search_count(self):
+        part_shop = sbol2.PartShop('https://synbiohub.org/public/igem')
+        # searchCount did not exist, see #322
+        self.assertTrue(hasattr(part_shop, 'searchCount'))
+        count = part_shop.searchCount('plasmid')
+        # Make sure we get an int back, not a string representation of a number
+        self.assertIs(type(count), int)
+        # Expecting at least 1 plasmid
+        self.assertGreater(count, 0)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Implement parts of `PartShop.searchCount` to support basic operations. Use of
`SearchQuery` is in the future. Add a search example from the documentation.

Also handle polymorphic search better. Handle the `PartShop.search` case where `property_uri` is not specified while
`offset` and `limit` are specified. This case appeared in the documentation.

Finally, update the search/searchCount documentation, particularly to remove references to `SearchResponse`, which is not necessary in Python.

Fixes #322 
Fixes #321 