### PR TITLE
Stop using strings for config options

### DIFF
--- a/docs/dbtl.rst
+++ b/docs/dbtl.rst
@@ -56,7 +56,7 @@ Branching and intersecting workflows are other common patterns of usage. For exa
 	workflow_step_7.plan = Plan('parameter_optimization')
 
 	setHomespace('')
-	Config.setOption('sbol_compliant_uris', False)  # Temporarily disable auto-construction of URIs
+	Config.setOption(ConfigOptions.SBOL_COMPLIANT_URIS, False)  # Temporarily disable auto-construction of URIs
 
 	workflow_step_1.agent = Agent('mailto:jdoe@sbols.org')
 	workflow_step_2.agent = workflow_step_1.agent
@@ -66,7 +66,7 @@ Branching and intersecting workflows are other common patterns of usage. For exa
 	workflow_step_6.agent = Agent('http://sys-bio.org/plate_reader_1')
 	workflow_step_7.agent = Agent('http://tellurium.analogmachine.org')
 
-	Config.setOption('sbol_compliant_uris', True)
+	Config.setOption(ConfigOptions.SBOL_COMPLIANT_URIS, True)
 	setHomespace('https://sys-bio.org')
 
 	doc.addActivity([workflow_step_1, workflow_step_2, workflow_step_3, workflow_step_4, workflow_step_5, workflow_step_6, workflow_step_7])

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -114,8 +114,8 @@ The first set of configuration options demonstrates 'open-world' mode, which mea
 .. code:: python
 
    >>> setHomespace('')
-   >>> Config.setOption('sbol_compliant_uris', False)
-   >>> Config.setOption('sbol_typed_uris', False)
+   >>> Config.setOption(ConfigOptions.SBOL_COMPLIANT_URIS, False)
+   >>> Config.setOption(ConfigOptions.SBOL_TYPED_URIS, False)
    >>> crispr_template = ModuleDefinition('http://sbols.org/CRISPR_Example/CRISPR_Template')
    >>> print(crispr_template)
    http://sbols.org/CRISPR_Example/CRISPR_Template
@@ -127,8 +127,8 @@ The second set of configuration options demonstrates use of a default namespace 
 .. code:: python
 
    >>> setHomespace('http://sbols.org/CRISPR_Example/')
-   >>> Config.setOption('sbol_compliant_uris', False)
-   >>> Config.setOption('sbol_typed_uris', False)
+   >>> Config.setOption(ConfigOptions.SBOL_COMPLIANT_URIS, False)
+   >>> Config.setOption(ConfigOptions.SBOL_TYPED_URIS, False)
    >>> crispr_template = ModuleDefinition('CRISPR_Template')
    >>> print(crispr_template)
    http://sbols.org/CRISPR_Example/CRISPR_Template
@@ -140,8 +140,8 @@ The third set of configuration options demonstrates SBOL-compliant mode. In this
 .. code:: python
 
    >>> setHomespace('http://sbols.org/CRISPR_Example/')
-   >>> Config.setOption('sbol_compliant_uris', True)
-   >>> Config.setOption('sbol_typed_uris', False)
+   >>> Config.setOption(ConfigOptions.SBOL_COMPLIANT_URIS, True)
+   >>> Config.setOption(ConfigOptions.SBOL_TYPED_URIS, False)
    >>> crispr_template = ModuleDefinition('CRISPR_Template')
    >>> print(crispr_template)
    http://sbols.org/CRISPR_Example/CRISPR_Template/1.0.0
@@ -153,8 +153,8 @@ The final example demonstrates typed URIs. When this option is enabled, the type
 .. code:: python
 
    >>> setHomespace('http://sbols.org/CRISPR_Example/')
-   >>> Config.setOption('sbol_compliant_uris', True)
-   >>> Config.setOption('sbol_typed_uris', True)
+   >>> Config.setOption(ConfigOptions.SBOL_COMPLIANT_URIS, True)
+   >>> Config.setOption(ConfigOptions.SBOL_TYPED_URIS, True)
    >>> crispr_template_md = ModuleDefinition('CRISPR_Template')
    >>> print(crispr_template)
    http://sbols.org/CRISPR_Example/ModuleDefinition/CRISPR_Template/1.0.0
@@ -219,8 +219,8 @@ When working interactively in a Python environment, typing long form URIs can be
 
 .. code:: python
 
-    >>> Config.setOption('sbol_compliant_uris', True)
-    >>> Config.setOption('sbol_typed_uris', False)
+    >>> Config.setOption(ConfigOptions.SBOL_COMPLIANT_URIS, True)
+    >>> Config.setOption(ConfigOptions.SBOL_TYPED_URIS, False)
     >>> crispr_template = doc.moduleDefinitions['CRISPR_Template']
     >>> cas9 = doc.componentDefinitions['cas9_generic']
 

--- a/examples/CRISPR_example.py
+++ b/examples/CRISPR_example.py
@@ -1,7 +1,7 @@
 from sbol2 import *
 
 setHomespace('http://sbols.org/CRISPR_Example')
-Config.setOption('sbol_typed_uris', False)
+Config.setOption(ConfigOptions.SBOL_TYPED_URIS, False)
 version = '1.0'
 doc = Document()
 

--- a/sbol2/componentdefinition.py
+++ b/sbol2/componentdefinition.py
@@ -233,7 +233,7 @@ class ComponentDefinition(TopLevel):
         # prior to execution. That means if a call fails, it may result in a modified
         # and incomplete data structure that will be difficult to fix when the user is
         # working interactively in the interpreter
-        if not Config.getOption('sbol_compliant_uris'):
+        if not Config.getOption(ConfigOptions.SBOL_COMPLIANT_URIS):
             raise EnvironmentError('Assemble method requires SBOL-compliance enabled')
 
         # Validate doc
@@ -377,8 +377,8 @@ class ComponentDefinition(TopLevel):
 
         if self.sequence is None:
             sequence_id = self.displayId + '_seq'
-            compliant_uris = Config.getOption('sbol_compliant_uris')
-            typed_uris = Config.getOption('sbol_typed_uris')
+            compliant_uris = Config.getOption(ConfigOptions.SBOL_COMPLIANT_URIS)
+            typed_uris = Config.getOption(ConfigOptions.SBOL_TYPED_URIS)
             if compliant_uris and typed_uris:
                 sequence_id = self.displayId
             self.sequence = Sequence(sequence_id)
@@ -520,7 +520,6 @@ class ComponentDefinition(TopLevel):
                     downstream_sequence_constraint.object
 
     def deleteUpstreamComponent(self, downstream_component):
-        # if Config.getOption('sbol_compliant_uris') == False:
         if not Config.getOption(ConfigOptions.SBOL_COMPLIANT_URIS):
             raise ValueError('SBOL-compliant URIs must be enabled to use this method')
         if downstream_component.identity not in self.components:

--- a/sbol2/config.py
+++ b/sbol2/config.py
@@ -95,7 +95,7 @@ class Config:
     for the libSBOL environment.
 
     Configuration variables are accessed
-    through the setOptions and getOptions methods.
+    through the setOption and getOption methods.
     """
 
     @staticmethod

--- a/sbol2/identified.py
+++ b/sbol2/identified.py
@@ -321,7 +321,7 @@ def replace_namespace(old_uri, target_namespace, rdf_type):
     if replacement_target not in old_uri:
         replacement_target = target_namespace
 
-    if Config.getOption('sbol_typed_uris'):
+    if Config.getOption(ConfigOptions.SBOL_TYPED_URIS):
         # Map into a typed namespace
         replacement = getHomespace() + '/' + class_name
     else:

--- a/sbol2/moduledefinition.py
+++ b/sbol2/moduledefinition.py
@@ -1,6 +1,6 @@
 from . import validation
 from .component import FunctionalComponent
-from .config import Config
+from .config import Config, ConfigOptions
 from .constants import *
 from .interaction import Interaction
 from .module import Module
@@ -222,7 +222,7 @@ class ModuleDefinition(TopLevel):
         :param list_of_modules: A list of submodule ModuleDefinitions.
         :return: None
         """
-        if not Config.getOption('sbol_compliant_uris'):
+        if not Config.getOption(ConfigOptions.SBOL_COMPLIANT_URIS):
             msg = 'This method only works when SBOL-compliance is enabled'
             raise SBOLError(msg, SBOLError.SBOL_ERROR_COMPLIANCE)
         for mdef in list_of_modules:

--- a/sbol2/partshop.py
+++ b/sbol2/partshop.py
@@ -143,8 +143,6 @@ class PartShop:
             elif not response:
                 raise SBOLError(response, SBOLErrorCode.SBOL_ERROR_BAD_HTTP_REQUEST)
             # Add content to document
-            serialization_format = Config.getOption('serialization_format')
-            Config.setOption('serialization_format', serialization_format)
             doc.readString(response.content)
             doc.resource_namespaces.add(self.resource)
 

--- a/sbol2/property.py
+++ b/sbol2/property.py
@@ -710,7 +710,7 @@ class OwnedObject(Property):
                 compliant_uri = posixpath.join(ns, uri, '')
             compliant_uri = URIRef(compliant_uri)
             persistent_id_matches = []
-            if Config.getOption('verbose') is True:
+            if Config.getOption(ConfigOptions.VERBOSE) is True:
                 print('Searching for TopLevel: ' + compliant_uri)
             for obj in object_store:
                 if compliant_uri in obj.identity:

--- a/sbol2/sequence.py
+++ b/sbol2/sequence.py
@@ -4,7 +4,7 @@ from rdflib import URIRef
 from .constants import *
 from .property import URIProperty, TextProperty
 from .toplevel import TopLevel
-from .config import Config
+from .config import Config, ConfigOptions
 from .sbolerror import SBOLError, SBOLErrorCode
 from .location import Range
 
@@ -127,7 +127,7 @@ class Sequence(TopLevel):
             for c in subcomponents:
                 cdef = self.doc.getComponentDefinition(c.definition)
                 if not cdef.sequence:
-                    if Config.getOption('sbol_compliant_uris'):
+                    if Config.getOption(ConfigOptions.SBOL_COMPLIANT_URIS):
                         seq = self.doc.sequences.create(cdef.displayId)
                         # cdef.sequence = seq
                         cdef.sequences = seq.identity
@@ -152,8 +152,10 @@ class Sequence(TopLevel):
                 # already exist
                 if len(sequence_annotations) == 0:
                     sa_instance = 0
-                    sa_id = cdef.displayId if Config.getOption('sbol_compliant_uris') \
-                        else cdef.identity
+                    if Config.getOption(ConfigOptions.SBOL_COMPLIANT_URIS):
+                        sa_id = cdef.displayId
+                    else:
+                        sa_id = cdef.identity
                     sa_id += '_annotation'
                     sa_uri = '%s/%s_%d/%s' % (parent_cdef.persistentIdentity, sa_id,
                                               sa_instance, cdef.version)
@@ -177,8 +179,10 @@ class Sequence(TopLevel):
                         ranges.append(loc)
                 else:
                     # Auto-construct a Range
-                    range_id = sa.displayId if Config.getOption('sbol_compliant_uris') \
-                        else sa.identity
+                    if Config.getOption(ConfigOptions.SBOL_COMPLIANT_URIS):
+                        range_id = sa.displayId
+                    else:
+                        range_id = sa.identity
                     r = sa.locations.createRange(range_id + '_range')
                     ranges.append(r)
                 if len(ranges) > 1:

--- a/test/test_collection.py
+++ b/test/test_collection.py
@@ -18,8 +18,8 @@ class TestCollection(unittest.TestCase):
     def setUp(self):
         # Always reset homespace
         sbol2.setHomespace(self.homespace)
-        sbol2.Config.setOption('sbol_typed_uris', True)
-        sbol2.Config.setOption('sbol_compliant_uris', True)
+        sbol2.Config.setOption(sbol2.ConfigOptions.SBOL_TYPED_URIS, True)
+        sbol2.Config.setOption(sbol2.ConfigOptions.SBOL_COMPLIANT_URIS, True)
 
     def testEmptyConstructor(self):
         # This is the default name in the collection constructor

--- a/test/test_componentdefinition.py
+++ b/test/test_componentdefinition.py
@@ -23,8 +23,8 @@ class TestComponentDefinitions(unittest.TestCase):
 
     def testAddComponentDefinition(self):
         sbol2.setHomespace('http://sbols.org/CRISPR_Example')
-        sbol2.Config.setOption('sbol_compliant_uris', True)
-        sbol2.Config.setOption('sbol_typed_uris', False)
+        sbol2.Config.setOption(sbol2.ConfigOptions.SBOL_COMPLIANT_URIS, True)
+        sbol2.Config.setOption(sbol2.ConfigOptions.SBOL_TYPED_URIS, False)
         expected = 'BB0001'
         test_CD = sbol2.ComponentDefinition(expected)
         doc = sbol2.Document()
@@ -319,7 +319,7 @@ class TestAssemblyRoutines(unittest.TestCase):
 
     def test_compile_sequence(self):
         doc = sbol2.Document()
-        sbol2.Config.setOption('sbol_typed_uris', True)
+        sbol2.Config.setOption(sbol2.ConfigOptions.SBOL_TYPED_URIS, True)
         gene = sbol2.ComponentDefinition("BB0001")
         promoter = sbol2.ComponentDefinition("R0010")
         CDS = sbol2.ComponentDefinition("B0032")
@@ -352,8 +352,8 @@ class TestAssemblyRoutines(unittest.TestCase):
         # different configuration options
         root_id = 'root'
         sub_id = 'sub'
-        sbol2.Config.setOption('sbol_compliant_uris', True)
-        sbol2.Config.setOption('sbol_typed_uris', True)
+        sbol2.Config.setOption(sbol2.ConfigOptions.SBOL_COMPLIANT_URIS, True)
+        sbol2.Config.setOption(sbol2.ConfigOptions.SBOL_TYPED_URIS, True)
         doc = sbol2.Document()
         root = doc.componentDefinitions.create(root_id)
         sub = doc.componentDefinitions.create(sub_id)
@@ -361,8 +361,8 @@ class TestAssemblyRoutines(unittest.TestCase):
         expected_identity = sbol2.getHomespace() + '/Sequence/' + root_id + '/1'
         self.assertEqual(root.sequence.identity, expected_identity)
 
-        sbol2.Config.setOption('sbol_compliant_uris', True)
-        sbol2.Config.setOption('sbol_typed_uris', False)
+        sbol2.Config.setOption(sbol2.ConfigOptions.SBOL_COMPLIANT_URIS, True)
+        sbol2.Config.setOption(sbol2.ConfigOptions.SBOL_TYPED_URIS, False)
         doc = sbol2.Document()
         root = doc.componentDefinitions.create(root_id)
         sub = doc.componentDefinitions.create(sub_id)
@@ -370,8 +370,8 @@ class TestAssemblyRoutines(unittest.TestCase):
         expected_identity = sbol2.getHomespace() + '/' + root_id + '_seq/1'
         self.assertEqual(root.sequence.identity, expected_identity)
 
-        sbol2.Config.setOption('sbol_compliant_uris', True)
-        sbol2.Config.setOption('sbol_typed_uris', True)
+        sbol2.Config.setOption(sbol2.ConfigOptions.SBOL_COMPLIANT_URIS, True)
+        sbol2.Config.setOption(sbol2.ConfigOptions.SBOL_TYPED_URIS, True)
 
     def test_recursive_compile(self):
         doc = sbol2.Document()
@@ -440,7 +440,7 @@ class TestAssemblyRoutines(unittest.TestCase):
         self.assertEqual(target_seq, 'atactagagttactagctactagagg')
 
     def test_assemble_with_displayIds(self):
-        sbol2.Config.setOption('sbol_typed_uris', True)
+        sbol2.Config.setOption(sbol2.ConfigOptions.SBOL_TYPED_URIS, True)
 
         doc = sbol2.Document()
         gene = sbol2.ComponentDefinition("BB0001")

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -1,8 +1,6 @@
 import unittest
 import warnings
 
-import rdflib
-
 import sbol2
 
 CRISPR_URI = 'http://sbols.org/CRISPR_Example/CRISPR_Template'
@@ -32,8 +30,8 @@ class TestConfig(unittest.TestCase):
     def test_openworld_noHomespace(self):
         """See: https://pysbol2.readthedocs.io/en/latest/getting_started.html"""
         sbol2.setHomespace('')
-        sbol2.Config.setOption('sbol_compliant_uris', False)
-        sbol2.Config.setOption('sbol_typed_uris', False)
+        sbol2.Config.setOption(sbol2.ConfigOptions.SBOL_COMPLIANT_URIS, False)
+        sbol2.Config.setOption(sbol2.ConfigOptions.SBOL_TYPED_URIS, False)
         crispr_template = sbol2.ModuleDefinition(CRISPR_URI)
         self.assertEqual(CRISPR_URI, str(crispr_template))
         self.assertEqual(CRISPR_URI, crispr_template.identity)
@@ -44,8 +42,8 @@ class TestConfig(unittest.TestCase):
         # This results in two slashes instead of one in both the original pySBOL
         # and the new code.
         sbol2.setHomespace('http://sbols.org/CRISPR_Example')
-        sbol2.Config.setOption('sbol_compliant_uris', False)
-        sbol2.Config.setOption('sbol_typed_uris', False)
+        sbol2.Config.setOption(sbol2.ConfigOptions.SBOL_COMPLIANT_URIS, False)
+        sbol2.Config.setOption(sbol2.ConfigOptions.SBOL_TYPED_URIS, False)
         crispr_template = sbol2.ModuleDefinition('CRISPR_Template')
         self.assertEqual(CRISPR_URI, str(crispr_template))
         self.assertEqual(CRISPR_URI, crispr_template.identity)
@@ -53,8 +51,8 @@ class TestConfig(unittest.TestCase):
     def test_SBOLCompliant(self):
         """See: https://pysbol2.readthedocs.io/en/latest/getting_started.html"""
         sbol2.setHomespace('http://sbols.org/CRISPR_Example')
-        sbol2.Config.setOption('sbol_compliant_uris', True)
-        sbol2.Config.setOption('sbol_typed_uris', False)
+        sbol2.Config.setOption(sbol2.ConfigOptions.SBOL_COMPLIANT_URIS, True)
+        sbol2.Config.setOption(sbol2.ConfigOptions.SBOL_TYPED_URIS, False)
         crispr_template = sbol2.ModuleDefinition('CRISPR_Template')
         self.assertEqual(CRISPR_URI_1, str(crispr_template))
         self.assertEqual(CRISPR_URI_1, crispr_template.identity)
@@ -62,8 +60,8 @@ class TestConfig(unittest.TestCase):
     def test_SBOLCompliant_typed(self):
         """See: https://pysbol2.readthedocs.io/en/latest/getting_started.html"""
         sbol2.setHomespace('http://sbols.org/CRISPR_Example')
-        sbol2.Config.setOption('sbol_compliant_uris', True)
-        sbol2.Config.setOption('sbol_typed_uris', True)
+        sbol2.Config.setOption(sbol2.ConfigOptions.SBOL_COMPLIANT_URIS, True)
+        sbol2.Config.setOption(sbol2.ConfigOptions.SBOL_TYPED_URIS, True)
         crispr_template_md = sbol2.ModuleDefinition('CRISPR_Template')
         expected_crispr_template_md = CRISPR_MD_URI_1
         self.assertEqual(expected_crispr_template_md, str(crispr_template_md))

--- a/test/test_document.py
+++ b/test/test_document.py
@@ -41,8 +41,8 @@ class TestDocument(unittest.TestCase):
         doc = sbol.Document()
         # Tutorial doesn't drop final forward slash, but this isn't right.
         sbol.setHomespace('http://sbols.org/CRISPR_Example')
-        sbol.Config.setOption('sbol_compliant_uris', True)
-        sbol.Config.setOption('sbol_typed_uris', False)
+        sbol.Config.setOption(sbol2.ConfigOptions.SBOL_COMPLIANT_URIS, True)
+        sbol.Config.setOption(sbol2.ConfigOptions.SBOL_TYPED_URIS, False)
         crispr_template = sbol.ModuleDefinition('CRISPR_Template')
         cas9 = sbol.ComponentDefinition('Cas9', sbol.BIOPAX_PROTEIN)
         doc.addModuleDefinition(crispr_template)
@@ -58,8 +58,8 @@ class TestDocument(unittest.TestCase):
     def test_addGetTopLevel_displayId(self):
         doc = sbol.Document()
         sbol.setHomespace('http://sbols.org/CRISPR_Example')
-        sbol.Config.setOption('sbol_compliant_uris', True)
-        sbol.Config.setOption('sbol_typed_uris', False)
+        sbol.Config.setOption(sbol2.ConfigOptions.SBOL_COMPLIANT_URIS, True)
+        sbol.Config.setOption(sbol2.ConfigOptions.SBOL_TYPED_URIS, False)
         crispr_template = sbol.ModuleDefinition('CRISPR_Template')
         cas9 = sbol.ComponentDefinition('Cas9', sbol.BIOPAX_PROTEIN)
         doc.addModuleDefinition(crispr_template)
@@ -74,8 +74,8 @@ class TestDocument(unittest.TestCase):
         doc = sbol.Document()
         # Tutorial doesn't drop final forward slash, but this isn't right.
         sbol.setHomespace('http://sbols.org/CRISPR_Example')
-        sbol.Config.setOption('sbol_compliant_uris', True)
-        sbol.Config.setOption('sbol_typed_uris', False)
+        sbol.Config.setOption(sbol2.ConfigOptions.SBOL_COMPLIANT_URIS, True)
+        sbol.Config.setOption(sbol2.ConfigOptions.SBOL_TYPED_URIS, False)
         crispr_template = sbol.ModuleDefinition('CRISPR_Template')
         cas9 = sbol.ComponentDefinition('Cas9', sbol.BIOPAX_PROTEIN)
         doc.addModuleDefinition(crispr_template)
@@ -187,8 +187,8 @@ class TestDocument(unittest.TestCase):
         # `value` parameter, so it was returning all identities in the
         # document.
         sbol.setHomespace('http://examples.org')
-        sbol.Config.setOption('sbol_compliant_uris', True)
-        sbol.Config.setOption('sbol_typed_uris', True)
+        sbol.Config.setOption(sbol2.ConfigOptions.SBOL_COMPLIANT_URIS, True)
+        sbol.Config.setOption(sbol2.ConfigOptions.SBOL_TYPED_URIS, True)
         doc = sbol.Document()
         cd = doc.moduleDefinitions.create('foo')
         cd.roles = sbol.SO_PROMOTER

--- a/test/test_identified.py
+++ b/test/test_identified.py
@@ -4,6 +4,7 @@ import unittest
 import rdflib
 
 import sbol2 as sbol
+import sbol2
 
 MODULE_LOCATION = os.path.dirname(os.path.abspath(__file__))
 PARTS_LOCATION = os.path.join(MODULE_LOCATION, 'resources', 'tutorial',
@@ -16,16 +17,16 @@ class TestIdentified(unittest.TestCase):
 
     def test_getDisplayId_SBOLCompliant(self):
         sbol.setHomespace('http://sbols.org/CRISPR_Example')
-        sbol.Config.setOption('sbol_compliant_uris', True)
-        sbol.Config.setOption('sbol_typed_uris', False)
+        sbol.Config.setOption(sbol2.ConfigOptions.SBOL_COMPLIANT_URIS, True)
+        sbol.Config.setOption(sbol2.ConfigOptions.SBOL_TYPED_URIS, False)
         expected = 'CRISPR_Template'
         crispr_template = sbol.ModuleDefinition(expected)
         self.assertEqual(crispr_template.displayId, expected)
 
     def test_getPersistentIdentity_SBOLCompliant(self):
         sbol.setHomespace('http://sbols.org/CRISPR_Example')
-        sbol.Config.setOption('sbol_compliant_uris', True)
-        sbol.Config.setOption('sbol_typed_uris', False)
+        sbol.Config.setOption(sbol2.ConfigOptions.SBOL_COMPLIANT_URIS, True)
+        sbol.Config.setOption(sbol2.ConfigOptions.SBOL_TYPED_URIS, False)
         crispr_template = sbol.ModuleDefinition('CRISPR_Template')
         expected = 'http://sbols.org/CRISPR_Example/CRISPR_Template'
         self.assertEqual(crispr_template.persistentIdentity,
@@ -33,15 +34,15 @@ class TestIdentified(unittest.TestCase):
 
     def test_getVersion_SBOLCompliant(self):
         sbol.setHomespace('http://sbols.org/CRISPR_Example')
-        sbol.Config.setOption('sbol_compliant_uris', True)
-        sbol.Config.setOption('sbol_typed_uris', False)
+        sbol.Config.setOption(sbol2.ConfigOptions.SBOL_COMPLIANT_URIS, True)
+        sbol.Config.setOption(sbol2.ConfigOptions.SBOL_TYPED_URIS, False)
         crispr_template = sbol.ModuleDefinition('CRISPR_Template')
         self.assertEqual(crispr_template.version, '1')
 
     def test_setDisplayId_SBOLCompliant(self):
         sbol.setHomespace('http://sbols.org/CRISPR_Example')
-        sbol.Config.setOption('sbol_compliant_uris', True)
-        sbol.Config.setOption('sbol_typed_uris', False)
+        sbol.Config.setOption(sbol2.ConfigOptions.SBOL_COMPLIANT_URIS, True)
+        sbol.Config.setOption(sbol2.ConfigOptions.SBOL_TYPED_URIS, False)
         crispr_template = sbol.ModuleDefinition('CRISPR_Template')
         crispr_template.displayId = 'test'
         self.assertEqual(str(crispr_template.displayId), 'test')
@@ -49,8 +50,8 @@ class TestIdentified(unittest.TestCase):
 
     def test_setPersistentIdentity_SBOLCompliant(self):
         sbol.setHomespace('http://sbols.org/CRISPR_Example')
-        sbol.Config.setOption('sbol_compliant_uris', True)
-        sbol.Config.setOption('sbol_typed_uris', False)
+        sbol.Config.setOption(sbol2.ConfigOptions.SBOL_COMPLIANT_URIS, True)
+        sbol.Config.setOption(sbol2.ConfigOptions.SBOL_TYPED_URIS, False)
         crispr_template = sbol.ModuleDefinition('CRISPR_Template')
         expected = 'test'
         crispr_template.persistentIdentity = expected
@@ -58,38 +59,38 @@ class TestIdentified(unittest.TestCase):
 
     def test_setVersion_SBOLCompliant(self):
         sbol.setHomespace('http://sbols.org/CRISPR_Example')
-        sbol.Config.setOption('sbol_compliant_uris', True)
-        sbol.Config.setOption('sbol_typed_uris', False)
+        sbol.Config.setOption(sbol2.ConfigOptions.SBOL_COMPLIANT_URIS, True)
+        sbol.Config.setOption(sbol2.ConfigOptions.SBOL_TYPED_URIS, False)
         crispr_template = sbol.ModuleDefinition('CRISPR_Template')
         crispr_template.version = '2'
         self.assertEqual(crispr_template.version, '2')
 
     def test_getDisplayId_hasHomespace(self):
         sbol.setHomespace('http://sbols.org/CRISPR_Example')
-        sbol.Config.setOption('sbol_compliant_uris', False)
-        sbol.Config.setOption('sbol_typed_uris', False)
+        sbol.Config.setOption(sbol2.ConfigOptions.SBOL_COMPLIANT_URIS, False)
+        sbol.Config.setOption(sbol2.ConfigOptions.SBOL_TYPED_URIS, False)
         crispr_template = sbol.ModuleDefinition('CRISPR_Template')
         self.assertEqual(None, crispr_template.displayId)
 
     def test_getPersistentIdentity_hasHomespace(self):
         sbol.setHomespace('http://sbols.org/CRISPR_Example')
-        sbol.Config.setOption('sbol_compliant_uris', False)
-        sbol.Config.setOption('sbol_typed_uris', False)
+        sbol.Config.setOption(sbol2.ConfigOptions.SBOL_COMPLIANT_URIS, False)
+        sbol.Config.setOption(sbol2.ConfigOptions.SBOL_TYPED_URIS, False)
         crispr_template = sbol.ModuleDefinition('CRISPR_Template')
         expected = 'http://sbols.org/CRISPR_Example/CRISPR_Template'
         self.assertEqual(crispr_template.persistentIdentity, expected)
 
     def test_getVersion_hasHomespace(self):
         sbol.setHomespace('http://sbols.org/CRISPR_Example')
-        sbol.Config.setOption('sbol_compliant_uris', False)
-        sbol.Config.setOption('sbol_typed_uris', False)
+        sbol.Config.setOption(sbol2.ConfigOptions.SBOL_COMPLIANT_URIS, False)
+        sbol.Config.setOption(sbol2.ConfigOptions.SBOL_TYPED_URIS, False)
         crispr_template = sbol.ModuleDefinition('CRISPR_Template')
         self.assertEqual(crispr_template.version, '1')
 
     def test_setPersistentIdentity_hasHomespace(self):
         sbol.setHomespace('http://sbols.org/CRISPR_Example')
-        sbol.Config.setOption('sbol_compliant_uris', False)
-        sbol.Config.setOption('sbol_typed_uris', False)
+        sbol.Config.setOption(sbol2.ConfigOptions.SBOL_COMPLIANT_URIS, False)
+        sbol.Config.setOption(sbol2.ConfigOptions.SBOL_TYPED_URIS, False)
         crispr_template = sbol.ModuleDefinition('CRISPR_Template')
         expected = 'test'
         crispr_template.persistentIdentity = expected
@@ -97,8 +98,8 @@ class TestIdentified(unittest.TestCase):
 
     def test_setVersion_hasHomespace(self):
         sbol.setHomespace('http://sbols.org/CRISPR_Example')
-        sbol.Config.setOption('sbol_compliant_uris', False)
-        sbol.Config.setOption('sbol_typed_uris', False)
+        sbol.Config.setOption(sbol2.ConfigOptions.SBOL_COMPLIANT_URIS, False)
+        sbol.Config.setOption(sbol2.ConfigOptions.SBOL_TYPED_URIS, False)
         crispr_template = sbol.ModuleDefinition('CRISPR_Template')
         crispr_template.version = '2'
         self.assertEqual(crispr_template.version, '2')
@@ -174,8 +175,8 @@ class TestCopy(unittest.TestCase):
         # whose values point to an object in the old namespace are also copied into the
         # new namespace
         sbol.setHomespace('http://examples.org')
-        sbol.Config.setOption('sbol_compliant_uris', True)
-        sbol.Config.setOption('sbol_typed_uris', False)
+        sbol.Config.setOption(sbol2.ConfigOptions.SBOL_COMPLIANT_URIS, True)
+        sbol.Config.setOption(sbol2.ConfigOptions.SBOL_TYPED_URIS, False)
         doc = sbol.Document()
         comp = sbol.ComponentDefinition('cd')
         seq = sbol.Sequence('seq')
@@ -214,8 +215,8 @@ class TestCopy(unittest.TestCase):
     def test_import_into_nontyped_namespace_from_typed_namespace(self):
         # Copy an sbol-typed URI to a non-typed, sbol-compliant URI
         sbol.setHomespace('http://examples.org')
-        sbol.Config.setOption('sbol_compliant_uris', True)
-        sbol.Config.setOption('sbol_typed_uris', True)
+        sbol.Config.setOption(sbol2.ConfigOptions.SBOL_COMPLIANT_URIS, True)
+        sbol.Config.setOption(sbol2.ConfigOptions.SBOL_TYPED_URIS, True)
 
         doc = sbol.Document()
         comp = sbol.ComponentDefinition('cd')
@@ -225,7 +226,7 @@ class TestCopy(unittest.TestCase):
         doc.addSequence(seq)
 
         # Import the object into the new namespace
-        sbol.Config.setOption('sbol_typed_uris', False)
+        sbol.Config.setOption(sbol2.ConfigOptions.SBOL_TYPED_URIS, False)
         old_homespace = sbol.getHomespace()
         sbol.setHomespace('http://acme.com')
         comp_copy = comp.copy(None, old_homespace)
@@ -243,8 +244,8 @@ class TestCopy(unittest.TestCase):
 
         # Copy an sbol-typed URI to a non-typed, sbol-compliant URI
         sbol.setHomespace('http://examples.org')
-        sbol.Config.setOption('sbol_typed_uris', False)
-        sbol.Config.setOption('sbol_compliant_uris', True)
+        sbol.Config.setOption(sbol2.ConfigOptions.SBOL_TYPED_URIS, False)
+        sbol.Config.setOption(sbol2.ConfigOptions.SBOL_COMPLIANT_URIS, True)
 
         doc = sbol.Document()
         comp = sbol.ComponentDefinition('cd')
@@ -254,7 +255,7 @@ class TestCopy(unittest.TestCase):
         doc.addSequence(seq)
 
         # Import the object into the new namespace
-        sbol.Config.setOption('sbol_typed_uris', True)
+        sbol.Config.setOption(sbol2.ConfigOptions.SBOL_TYPED_URIS, True)
         old_homespace = sbol.getHomespace()
         sbol.setHomespace('http://acme.com')
         comp_copy = comp.copy(None, old_homespace)
@@ -290,7 +291,7 @@ class TestCopy(unittest.TestCase):
     def test_copy_and_increment_version(self):
         # When copying an object within the same Document, the version should be
         # automatically incrememented
-        sbol.Config.setOption('sbol_typed_uris', False)
+        sbol.Config.setOption(sbol2.ConfigOptions.SBOL_TYPED_URIS, False)
         doc = sbol.Document()
         comp = sbol.ComponentDefinition('foo', sbol.constants.BIOPAX_DNA, '1.0.0')
         doc.addComponentDefinition(comp)
@@ -303,7 +304,7 @@ class TestCopy(unittest.TestCase):
         self.assertEqual(comp_copy.types[0], sbol.constants.BIOPAX_DNA)
 
     def test_copy_to_new_document(self):
-        sbol.Config.setOption('sbol_typed_uris', False)
+        sbol.Config.setOption(sbol2.ConfigOptions.SBOL_TYPED_URIS, False)
         doc = sbol.Document()
         comp1 = sbol.ComponentDefinition('cd1', sbol.constants.BIOPAX_DNA, '2')
         comp2 = sbol.ComponentDefinition('cd2', sbol.constants.BIOPAX_DNA, '2')

--- a/test/test_implementation.py
+++ b/test/test_implementation.py
@@ -1,8 +1,7 @@
 import unittest
 
-import rdflib
-
 import sbol2 as sbol
+import sbol2
 
 
 class TestImplementation(unittest.TestCase):
@@ -18,8 +17,8 @@ class TestImplementation(unittest.TestCase):
     def setUp(self):
         # Always reset homespace
         sbol.setHomespace(self.homespace)
-        sbol.Config.setOption('sbol_typed_uris', True)
-        sbol.Config.setOption('sbol_compliant_uris', True)
+        sbol.Config.setOption(sbol2.ConfigOptions.SBOL_TYPED_URIS, True)
+        sbol.Config.setOption(sbol2.ConfigOptions.SBOL_COMPLIANT_URIS, True)
 
     def test_implementation_exported(self):
         self.assertIn('Implementation', dir(sbol))

--- a/test/test_interaction.py
+++ b/test/test_interaction.py
@@ -1,8 +1,7 @@
 import unittest
 
-import rdflib
-
 import sbol2 as sbol
+import sbol2
 
 
 class TestInteraction(unittest.TestCase):
@@ -18,8 +17,8 @@ class TestInteraction(unittest.TestCase):
     def setUp(self):
         # Always reset homespace
         sbol.setHomespace(self.homespace)
-        sbol.Config.setOption('sbol_typed_uris', True)
-        sbol.Config.setOption('sbol_compliant_uris', True)
+        sbol.Config.setOption(sbol2.ConfigOptions.SBOL_TYPED_URIS, True)
+        sbol.Config.setOption(sbol2.ConfigOptions.SBOL_COMPLIANT_URIS, True)
 
     def testEmptyConstructor(self):
         # This is the default name in the interaction constructor

--- a/test/test_sequence.py
+++ b/test/test_sequence.py
@@ -45,7 +45,7 @@ class TestSequence(unittest.TestCase):
 
     def testSequenceElement(self):
         sbol2.setHomespace('http://sbols.org/CRISPR_Example')
-        sbol2.Config.setOption('sbol_typed_uris', False)
+        sbol2.Config.setOption(sbol2.ConfigOptions.SBOL_TYPED_URIS, False)
         doc = sbol2.Document()
         doc.read(CRISPR_EXAMPLE)
         # Sequence to test against
@@ -60,7 +60,7 @@ class TestSequence(unittest.TestCase):
 
     def testUpdateSequenceElement(self):
         sbol2.setHomespace('http://sbols.org/CRISPR_Example')
-        sbol2.Config.setOption('sbol_typed_uris', False)
+        sbol2.Config.setOption(sbol2.ConfigOptions.SBOL_TYPED_URIS, False)
         doc = sbol2.Document()
         doc.read(CRISPR_EXAMPLE)
         # Sequence to test against
@@ -72,7 +72,7 @@ class TestSequence(unittest.TestCase):
     # File I/O Tests
     def testUpdateWrite(self):
         sbol2.setHomespace('http://sbols.org/CRISPR_Example')
-        sbol2.Config.setOption('sbol_typed_uris', False)
+        sbol2.Config.setOption(sbol2.ConfigOptions.SBOL_TYPED_URIS, False)
         doc = sbol2.Document()
         doc.read(CRISPR_EXAMPLE)
         # Sequence to test against


### PR DESCRIPTION
Use the defined constants instead of sprinkling strings all over the code, tests, examples, and documentation. Computer Science 101. Define a constant and use it.

Fixes #36