### PR TITLE
Improve URL validation in PartShop #92

### DIFF
--- a/sbol2/partshop.py
+++ b/sbol2/partshop.py
@@ -41,13 +41,21 @@ class PartShop:
         self.spoofed_resource = self._validate_url(spoofed_url, 'spoofed')
 
     def _validate_url(self, url, url_name):
-        # This feels like a weak validation
-        # Should we verify that it is a string?
-        #   [1, 2, 3] will pass this test, and surely break something else later.
-        # Should we use urllib.parse.urlparse?
-        #   It doesn't do a whole lot, but catches some things this code doesn't
-        if isinstance(url, str):
+        """ Function to validate url before further processing
+        """
+
+        # type check to ensure passed url is a string
+        if not isinstance(url,str):
+            msg = ('PartShop initialization failed. The {} URL '
+                   + 'is not of type string').format(url_name)
             raise SBOLError(msg, SBOLErrorCode.SBOL_ERROR_INVALID_ARGUMENT)
+        # authenticity check with urlparse so ensure correct scheme and netloc present
+        url_peices = urllib.parse.urlparse(url)
+        if not all([url_peices.scheme in ["http", "https"], url_peices.netloc]):
+            msg = ('PartShop initialization failed. The {} URL '
+                   + 'was not valid').format(url_name)
+            raise SBOLError(msg, SBOLErrorCode.SBOL_ERROR_INVALID_ARGUMENT)
+        # string check to ensure length > 0 and does not contain terminal "\"
         if len(url) > 0 and url[-1] == '/':
             msg = ('PartShop initialization failed. The {} URL '
                    + 'should not contain a terminal backlash')

--- a/sbol2/partshop.py
+++ b/sbol2/partshop.py
@@ -41,26 +41,26 @@ class PartShop:
         self.spoofed_resource = self._validate_url(spoofed_url, 'spoofed')
 
     def _validate_url(self, url, url_name):
-        """ Function to validate url with type checking, urlparse and                    
+        """ Function to validate url with type checking, urlparse and
         terminal forward slash's
         """
         # Type check to ensure passed url is a string
         if not isinstance(url, str):
             msg = ('PartShop initialization failed. The {} URL '
-                + 'is not of type string').format(url_name)
+                   + 'is not of type string').format(url_name)
             raise SBOLError(msg, SBOLErrorCode.SBOL_ERROR_INVALID_ARGUMENT)
         # Authenticity check with urlparse as to ensure correct scheme and
         # netloc present
         url_pieces = urllib.parse.urlparse(url)
         if not all([url_pieces.scheme in ['http', 'https'],
-                url_pieces.netloc]):
+                   url_pieces.netloc]):
             msg = ('PartShop initialization failed. The {} URL '
-                + 'was not valid').format(url_name)
+                   + 'was not valid').format(url_name)
             raise SBOLError(msg, SBOLErrorCode.SBOL_ERROR_INVALID_ARGUMENT)
         # String check to ensure length > 0 and does not contain terminal "/"
         if len(url) > 0 and url[-1] == '/':
-            msg = 'PartShop initialization failed. The {} URL ' \
-                + 'should not contain a terminal forward slash'
+            msg = ('PartShop initialization failed. The {} URL '
+                   + 'should not contain a terminal forward slash')
             msg = msg.format(url_name)
             raise SBOLError(msg, SBOLErrorCode.SBOL_ERROR_INVALID_ARGUMENT)
         return url

--- a/sbol2/partshop.py
+++ b/sbol2/partshop.py
@@ -28,7 +28,7 @@ class PartShop:
     """A class which provides an API front-end for
     online bioparts repositories"""
 
-    def __init__(self, url, spoofed_url='https://unset-spoofed-url-variable'):
+    def __init__(self, url, spoofed_url=''):
         """
 
         :param url: The URL of the online repository (as a str)
@@ -44,6 +44,10 @@ class PartShop:
         """ Function to validate url with type checking, urlparse and
         terminal forward slash's
         """
+        # If url_name = spoofed and url = '' pass as spoofed_resource
+        # passes validation whilst initiating PartShop Class
+        if url_name == "spoofed" and url == '':
+            return url
         # Type check to ensure passed url is a string
         if not isinstance(url, str):
             msg = ('PartShop initialization failed. The {} URL '

--- a/sbol2/partshop.py
+++ b/sbol2/partshop.py
@@ -49,8 +49,8 @@ class PartShop:
                    + 'is not of type string').format(url_name)
             raise SBOLError(msg, SBOLErrorCode.SBOL_ERROR_INVALID_ARGUMENT)
         # Authenticity check with urlparse as to ensure correct scheme and netloc present
-        url_peices = urllib.parse.urlparse(url)
-        if not all([url_peices.scheme in ["http", "https"], url_peices.netloc]):
+        url_pieces = urllib.parse.urlparse(url)
+        if not all([url_pieces.scheme in ["http", "https"], url_pieces.netloc]):
             msg = ('PartShop initialization failed. The {} URL '
                    + 'was not valid').format(url_name)
             raise SBOLError(msg, SBOLErrorCode.SBOL_ERROR_INVALID_ARGUMENT)

--- a/sbol2/partshop.py
+++ b/sbol2/partshop.py
@@ -42,10 +42,12 @@ class PartShop:
 
     def _validate_url(self, url, url_name):
         """ Function to validate url with type checking, urlparse and
-        terminal forward slash's
+        terminal forward slash's as well as allowing spoofed url to
+        pass as ''
         """
-        # If url_name = spoofed and url = '' pass as spoofed_resource
-        # passes validation whilst initiating PartShop Class
+        # If url_name = spoofed and url = '' pass, as spoofed_resource
+        # initialises with default spoofed_url = '' when objects are
+        # created, ideal behavior should not throw errors in such case.
         if url_name == "spoofed" and url == '':
             return url
         # Type check to ensure passed url is a string

--- a/sbol2/partshop.py
+++ b/sbol2/partshop.py
@@ -40,27 +40,30 @@ class PartShop:
         self.key = ''
         self.spoofed_resource = self._validate_url(spoofed_url, 'spoofed')
 
-    def _validate_url(self, url, url_name):
-        """ Function to validate url with type checking, urlparse and terminal forward slash's
-        """
-        # Type check to ensure passed url is a string
-        if not isinstance(url,str):
-            msg = ('PartShop initialization failed. The {} URL '
-                   + 'is not of type string').format(url_name)
-            raise SBOLError(msg, SBOLErrorCode.SBOL_ERROR_INVALID_ARGUMENT)
-        # Authenticity check with urlparse as to ensure correct scheme and netloc present
-        url_pieces = urllib.parse.urlparse(url)
-        if not all([url_pieces.scheme in ["http", "https"], url_pieces.netloc]):
-            msg = ('PartShop initialization failed. The {} URL '
-                   + 'was not valid').format(url_name)
-            raise SBOLError(msg, SBOLErrorCode.SBOL_ERROR_INVALID_ARGUMENT)
-        # String check to ensure length > 0 and does not contain terminal "/"
-        if len(url) > 0 and url[-1] == '/':
-            msg = ('PartShop initialization failed. The {} URL '
-                   + 'should not contain a terminal forward slash')
-            msg = msg.format(url_name)
-            raise SBOLError(msg, SBOLErrorCode.SBOL_ERROR_INVALID_ARGUMENT)
-        return url
+def _validate_url(self, url, url_name):
+    """ Function to validate url with type checking, urlparse and                    
+    terminal forward slash's
+    """
+    # Type check to ensure passed url is a string
+    if not isinstance(url, str):
+        msg = ('PartShop initialization failed. The {} URL '
+               + 'is not of type string').format(url_name)
+        raise SBOLError(msg, SBOLErrorCode.SBOL_ERROR_INVALID_ARGUMENT)
+    # Authenticity check with urlparse as to ensure correct scheme and
+    # netloc present
+    url_pieces = urllib.parse.urlparse(url)
+    if not all([url_pieces.scheme in ['http', 'https'],
+               url_pieces.netloc]):
+        msg = ('PartShop initialization failed. The {} URL '
+               + 'was not valid').format(url_name)
+        raise SBOLError(msg, SBOLErrorCode.SBOL_ERROR_INVALID_ARGUMENT)
+    # String check to ensure length > 0 and does not contain terminal "/"
+    if len(url) > 0 and url[-1] == '/':
+        msg = 'PartShop initialization failed. The {} URL ' \
+            + 'should not contain a terminal forward slash'
+        msg = msg.format(url_name)
+        raise SBOLError(msg, SBOLErrorCode.SBOL_ERROR_INVALID_ARGUMENT)
+    return url
 
     @property
     def logger(self):

--- a/sbol2/partshop.py
+++ b/sbol2/partshop.py
@@ -40,30 +40,30 @@ class PartShop:
         self.key = ''
         self.spoofed_resource = self._validate_url(spoofed_url, 'spoofed')
 
-def _validate_url(self, url, url_name):
-    """ Function to validate url with type checking, urlparse and                    
-    terminal forward slash's
-    """
-    # Type check to ensure passed url is a string
-    if not isinstance(url, str):
-        msg = ('PartShop initialization failed. The {} URL '
-               + 'is not of type string').format(url_name)
-        raise SBOLError(msg, SBOLErrorCode.SBOL_ERROR_INVALID_ARGUMENT)
-    # Authenticity check with urlparse as to ensure correct scheme and
-    # netloc present
-    url_pieces = urllib.parse.urlparse(url)
-    if not all([url_pieces.scheme in ['http', 'https'],
-               url_pieces.netloc]):
-        msg = ('PartShop initialization failed. The {} URL '
-               + 'was not valid').format(url_name)
-        raise SBOLError(msg, SBOLErrorCode.SBOL_ERROR_INVALID_ARGUMENT)
-    # String check to ensure length > 0 and does not contain terminal "/"
-    if len(url) > 0 and url[-1] == '/':
-        msg = 'PartShop initialization failed. The {} URL ' \
-            + 'should not contain a terminal forward slash'
-        msg = msg.format(url_name)
-        raise SBOLError(msg, SBOLErrorCode.SBOL_ERROR_INVALID_ARGUMENT)
-    return url
+    def _validate_url(self, url, url_name):
+        """ Function to validate url with type checking, urlparse and                    
+        terminal forward slash's
+        """
+        # Type check to ensure passed url is a string
+        if not isinstance(url, str):
+            msg = ('PartShop initialization failed. The {} URL '
+                + 'is not of type string').format(url_name)
+            raise SBOLError(msg, SBOLErrorCode.SBOL_ERROR_INVALID_ARGUMENT)
+        # Authenticity check with urlparse as to ensure correct scheme and
+        # netloc present
+        url_pieces = urllib.parse.urlparse(url)
+        if not all([url_pieces.scheme in ['http', 'https'],
+                url_pieces.netloc]):
+            msg = ('PartShop initialization failed. The {} URL '
+                + 'was not valid').format(url_name)
+            raise SBOLError(msg, SBOLErrorCode.SBOL_ERROR_INVALID_ARGUMENT)
+        # String check to ensure length > 0 and does not contain terminal "/"
+        if len(url) > 0 and url[-1] == '/':
+            msg = 'PartShop initialization failed. The {} URL ' \
+                + 'should not contain a terminal forward slash'
+            msg = msg.format(url_name)
+            raise SBOLError(msg, SBOLErrorCode.SBOL_ERROR_INVALID_ARGUMENT)
+        return url
 
     @property
     def logger(self):

--- a/sbol2/partshop.py
+++ b/sbol2/partshop.py
@@ -41,24 +41,23 @@ class PartShop:
         self.spoofed_resource = self._validate_url(spoofed_url, 'spoofed')
 
     def _validate_url(self, url, url_name):
-        """ Function to validate url before further processing
+        """ Function to validate url with type checking, urlparse and terminal forward slash's
         """
-
-        # type check to ensure passed url is a string
+        # Type check to ensure passed url is a string
         if not isinstance(url,str):
             msg = ('PartShop initialization failed. The {} URL '
                    + 'is not of type string').format(url_name)
             raise SBOLError(msg, SBOLErrorCode.SBOL_ERROR_INVALID_ARGUMENT)
-        # authenticity check with urlparse so ensure correct scheme and netloc present
+        # Authenticity check with urlparse as to ensure correct scheme and netloc present
         url_peices = urllib.parse.urlparse(url)
         if not all([url_peices.scheme in ["http", "https"], url_peices.netloc]):
             msg = ('PartShop initialization failed. The {} URL '
                    + 'was not valid').format(url_name)
             raise SBOLError(msg, SBOLErrorCode.SBOL_ERROR_INVALID_ARGUMENT)
-        # string check to ensure length > 0 and does not contain terminal "\"
+        # String check to ensure length > 0 and does not contain terminal "/"
         if len(url) > 0 and url[-1] == '/':
             msg = ('PartShop initialization failed. The {} URL '
-                   + 'should not contain a terminal backlash')
+                   + 'should not contain a terminal forward slash')
             msg = msg.format(url_name)
             raise SBOLError(msg, SBOLErrorCode.SBOL_ERROR_INVALID_ARGUMENT)
         return url

--- a/sbol2/partshop.py
+++ b/sbol2/partshop.py
@@ -28,7 +28,7 @@ class PartShop:
     """A class which provides an API front-end for
     online bioparts repositories"""
 
-    def __init__(self, url, spoofed_url=''):
+    def __init__(self, url, spoofed_url='https://unset-spoofed-url-variable'):
         """
 
         :param url: The URL of the online repository (as a str)

--- a/sbol2/partshop.py
+++ b/sbol2/partshop.py
@@ -46,6 +46,8 @@ class PartShop:
         #   [1, 2, 3] will pass this test, and surely break something else later.
         # Should we use urllib.parse.urlparse?
         #   It doesn't do a whole lot, but catches some things this code doesn't
+        if isinstance(url, str):
+            raise SBOLError(msg, SBOLErrorCode.SBOL_ERROR_INVALID_ARGUMENT)
         if len(url) > 0 and url[-1] == '/':
             msg = ('PartShop initialization failed. The {} URL '
                    + 'should not contain a terminal backlash')

--- a/test/test_partshop.py
+++ b/test/test_partshop.py
@@ -297,6 +297,46 @@ WHERE {
         # Expecting at least 1 plasmid
         self.assertGreater(count, 0)
 
+    def test_validate_url_forwardslash(self):
+        # Tests whether the _validate_url() sucessfully filters
+        # out urls containing a terminal forward slash
+        part_shop = sbol2.PartShop('https://initialise-partshop')
+        self.assertRaises(TypeError,
+                          part_shop._validate_url,
+                          'https://stackoverflow.com/')
+
+    def test_validate_url_missing_netloc(self):
+        # Tests whether the _validate_url() sucessfully filters
+        # out urls with non existent netlocs
+        part_shop = sbol2.PartShop('https://initialise-partshop')
+        self.assertRaises(TypeError,
+                          part_shop._validate_url,
+                          'https://')
+
+    def test_validate_url_invalid_scheme(self):
+        # Tests whether the _validate_url() sucessfully filters
+        # out urls with schemes not equal to "http" or "https"
+        part_shop = sbol2.PartShop('https://initialise-partshop')
+        self.assertRaises(TypeError,
+                          part_shop._validate_url,
+                          'file://google.com')
+
+    def test_validate_url_hidden_list(self):
+        # Tests whether the _validate_url() sucessfully filters
+        # out urls as a string of a list
+        part_shop = sbol2.PartShop('https://initialise-partshop')
+        self.assertRaises(TypeError,
+                          part_shop._validate_url,
+                          '[1,2,3]')
+
+    def test_validate_url_type_check(self):
+        # Tests whether the _validate_url() sucessfully filters
+        # out urls of type which is not equal to string
+        part_shop = sbol2.PartShop('https://initialise-partshop')
+        self.assertRaises(TypeError,
+                          part_shop._validate_url,
+                          [1, 2, 3])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### This is a pull request adressing:
### Improve URL validation in PartShop #92

As suggested I have added two embedded if statements following your suggestions on the issue page. One for using `isinstance` to raise error if input is not of type str, and second using urlparse to ensure the scheme is one of "http" or "https" as well as a existing netloc. In addition to your current preventing terminal "/" function.

I have tested the current fuction with the follwing urls:
> "https://stackoverflow.com"      -> Valid
"https://stackoverflow.com/"    -> Error( terminal forward slash )
"https://"                                      -> Error ( non-existant netloc )
"/stackoverflow.com"                 -> Error ( invalid scheme )
"[1,2,3]"   -> Error ( invalid scheme )
[1,2,3]    -> Error ( not string )

If there is any questions, suggestions or misunderstanding of the code on my half let me know as I'd like to continue working on this project in the future 🚀
Benedict

Fixes #92