### PR TITLE
Implement PartShop advanced search

### DIFF
--- a/examples/advanced-search.py
+++ b/examples/advanced-search.py
@@ -1,0 +1,31 @@
+import urllib.parse
+
+import requests
+
+search_text = 'NAND'
+offset = 0
+limit = 10
+
+# search_url = parseURLDomain(self.resource)
+search_url = 'https://synbiohub.org'
+
+# query = dict(objectType=parseClassName(object_type))
+query = dict(objectType='ComponentDefinition')
+query = urllib.parse.urlencode(query)
+search_text = urllib.parse.quote(search_text)
+params = dict(offset=offset, limit=limit)
+params = urllib.parse.urlencode(params)
+query_url = f'{search_url}/search/{query}&{search_text}/?{params}'
+print(query_url)
+
+# return self._search(query_url)
+headers = {'Accept': 'text/plain'}
+# if self.key:
+#     headers['X-authorization'] = self.key
+
+# self.logger.info('search query: %s', url)
+response = requests.get(query_url, headers=headers)
+if not response:
+    # Something went wrong
+    print('Failure')
+print(response.json())

--- a/sbol2/__init__.py
+++ b/sbol2/__init__.py
@@ -29,6 +29,7 @@ from .module import Module
 from .moduledefinition import ModuleDefinition
 from .object import SBOLObject
 from .participation import Participation
+from .searchquery import SearchQuery
 from .partshop import PartShop
 from .property import DateTimeProperty, FloatProperty, IntProperty
 from .property import LiteralProperty, OwnedObject

--- a/sbol2/constants.py
+++ b/sbol2/constants.py
@@ -15,6 +15,10 @@ SYSBIO_URI = "http://sys-bio.org"
 # PROVO = "https://www.w3.org/TR/prov-o/"
 OM_URI = 'http://www.ontology-of-units-of-measure.org/resource/om-2/'
 
+# A private namespace for pySBOL2 URIs
+PYSBOL2_NS = rdflib.Namespace('https://github.com/SynBioDex/pySBOL2')
+
+
 # rdf nodes used in SBOL
 NODENAME_ABOUT = "rdf:about"
 NODENAME_RESOURCE = "rdf:resource"

--- a/sbol2/partshop.py
+++ b/sbol2/partshop.py
@@ -17,11 +17,7 @@ from .constants import *
 from .sbolerror import SBOLError
 from .sbolerror import SBOLErrorCode
 from .identified import Identified
-
-
-class SearchQuery:
-    """This is a stub until SearchQuery is implemented."""
-    pass
+from . import SearchQuery
 
 
 class PartShop:

--- a/sbol2/partshop.py
+++ b/sbol2/partshop.py
@@ -384,13 +384,29 @@ class PartShop:
         query_url = f'{search_url}/search/{query}&/?{params}'
         return self._search(query_url)
 
-    def search(self, search_text: str,
+    def search_advanced(self, search_query: SearchQuery):
+        # See https://synbiohub.github.io/api-docs/#search-metadata
+        search_url = parseURLDomain(self.resource)
+        query = search_query.query_dict()
+        # if search_text.startswith('http'):
+        #     search_text = f"<{search_text}>"
+        # else:
+        #     search_text = f"'{search_text}'"
+        # query[parseClassName(property_uri)] = search_text
+        query = urllib.parse.urlencode(query)
+        params = dict(offset=(search_query.offset),
+                      limit=(search_query.limit))
+        params = urllib.parse.urlencode(params)
+        query_url = f'{search_url}/search/{query}&/?{params}'
+        return self._search(query_url)
+
+    def search(self, search_text: Union[str, SearchQuery],
                object_type: Optional[str] = SBOL_COMPONENT_DEFINITION,
                property_uri: Optional[Union[str, int]] = None,
                offset: int = 0, limit: int = 25) -> List[Identified]:
         # if search_text is a SearchQuery, dispatch to search_advanced
         if type(search_text) is SearchQuery:
-            raise NotImplementedError('search using SearchQuery is not implemented')
+            return self.search_advanced(search_text)
         if type(property_uri) is int:
             # User called without property_uri and with offset. Shift args
             if offset > 0:

--- a/sbol2/partshop.py
+++ b/sbol2/partshop.py
@@ -421,15 +421,7 @@ class PartShop:
         return self.search_exact(search_text, object_type, property_uri,
                                  offset, limit)
 
-    def _search_count(self, search_text, object_type, property_uri):
-        search_url = parseURLDomain(self.resource)
-        query = dict(objectType=parseClassName(object_type))
-        query = urllib.parse.urlencode(query)
-        search_text = urllib.parse.quote(search_text)
-        # params = dict(offset=offset, limit=limit)
-        # params = urllib.parse.urlencode(params)
-        # query_url = f'{search_url}/search/{query}&{search_text}/?{params}'
-        url = f'{search_url}/searchCount/{query}&{search_text}/'
+    def _search_count(self, url):
         headers = {'Accept': 'text/plain'}
         if self.key:
             headers['X-authorization'] = self.key
@@ -441,16 +433,34 @@ class PartShop:
         # Everything looks good, parse and return the results
         return int(response.text)
 
+    def search_count(self, search_text, object_type, property_uri):
+        search_url = parseURLDomain(self.resource)
+        query = dict(objectType=parseClassName(object_type))
+        query = urllib.parse.urlencode(query)
+        search_text = urllib.parse.quote(search_text)
+        # params = dict(offset=offset, limit=limit)
+        # params = urllib.parse.urlencode(params)
+        # query_url = f'{search_url}/search/{query}&{search_text}/?{params}'
+        url = f'{search_url}/searchCount/{query}&{search_text}/'
+        return self._search_count(url)
+
+    def search_count_advanced(self, search_query):
+        search_url = parseURLDomain(self.resource)
+        query = search_query.query_dict()
+        query = urllib.parse.urlencode(query)
+        url = f'{search_url}/searchCount/{query}&/'
+        return self._search_count(url)
+
     def searchCount(self, search_text, object_type=None, property_uri=None):
         """Returns the number of records matching the given criteria.
         """
-        # if search_text is a SearchQuery, dispatch to ???
+        # if search_text is a SearchQuery, dispatch to search_count_advanced
         if type(search_text) is SearchQuery:
-            raise NotImplementedError('search using SearchQuery is not implemented')
+            return self.search_count_advanced(search_text)
 
         # if object_type is not specified, default to SBOL_COMPONENT_DEFINITION
         if object_type is None:
             object_type = SBOL_COMPONENT_DEFINITION
 
         # Dispatch to the internal search count method
-        return self._search_count(search_text, object_type, property_uri)
+        return self.search_count(search_text, object_type, property_uri)

--- a/sbol2/searchquery.py
+++ b/sbol2/searchquery.py
@@ -44,14 +44,13 @@ class SearchQuery(TopLevel):
         if collection:
             result['collection'] = f'<{collection}>'
         # Now gather all the properties the user has set
-        skip_list = [OBJECT_TYPE_URI, OFFSET_URI, LIMIT_URI,
-                     SBOL_IDENTITY, SBOL_PERSISTENT_IDENTITY, SBOL_DISPLAY_ID,
-                     SBOL_COLLECTION
-                     ]
+        skip_list = [SBOL_IDENTITY,
+                     OBJECT_TYPE_URI, OFFSET_URI, LIMIT_URI,
+                     SBOL_COLLECTION]
         for k, v in self.properties.items():
             if k in skip_list:
                 continue
-            if not v:
+            if not v or not v[0]:
                 # If there is no value, skip it
                 # this can happen if no value is supplied for an attribute
                 continue

--- a/sbol2/searchquery.py
+++ b/sbol2/searchquery.py
@@ -1,0 +1,34 @@
+from .config import parseNamespace
+from .constants import *
+from .property import URIProperty, IntProperty, TextProperty
+from .toplevel import TopLevel
+
+SEARCH_QUERY_URI: str = PYSBOL2_NS.SearchQuery.toPython()
+OBJECT_TYPE_URI: str = PYSBOL2_NS.ObjectType.toPython()
+OFFSET_URI: str = PYSBOL2_NS.Offset.toPython()
+LIMIT_URI: str = PYSBOL2_NS.Limit.toPython()
+
+
+class SearchQuery(TopLevel):
+    """Search terms to support PartShop advanced search."""
+    def __init__(self, search_target: str = SBOL_COMPONENT_DEFINITION,
+                 offset: int = 0, limit: int = 25):
+        super().__init__(SEARCH_QUERY_URI)
+        # Set attributes from TopLevel
+        self.displayId = ''
+        self.persistentIdentity = ''
+        self.version = ''
+        # Add some attributes
+        self.objectType = URIProperty(self, OBJECT_TYPE_URI, '0', '1', None, search_target)
+        self.offset = IntProperty(self, OFFSET_URI, '0', '1', None, offset)
+        self.limit = IntProperty(self, LIMIT_URI, '0', '1', None, limit)
+
+    def __setitem__(self, key, value):
+        if parseNamespace(key) == '':
+            uri = SBOL_URI + '#' + 'key'
+        else:
+            uri = key
+        TextProperty(self, uri, '0', '1', None, value)
+
+    def __getitem__(self, item):
+        return self.properties[item][0].toPython()

--- a/test/test_searchquery.py
+++ b/test/test_searchquery.py
@@ -10,9 +10,9 @@ class TestSearchQuery(unittest.TestCase):
 
     def test_search_query1(self):
         query = sbol2.SearchQuery()
-        query[sbol2.SBOL_ROLES] = sbol2.BIOPAX_DNA
-        self.assertIn(sbol2.SBOL_ROLES, query.properties)
-        self.assertEqual(sbol2.BIOPAX_DNA, query[sbol2.SBOL_ROLES])
+        query[sbol2.SBOL_TYPES] = sbol2.BIOPAX_DNA
+        self.assertIn(sbol2.SBOL_TYPES, query.properties)
+        self.assertEqual(sbol2.BIOPAX_DNA, query[sbol2.SBOL_TYPES])
 
     def test_gsoc_example_1_title(self):
         # See issue #240
@@ -33,6 +33,26 @@ class TestSearchQuery(unittest.TestCase):
         # All items in response should have name == GFP exactly.
         names = [r.name == title for r in response]
         self.assertTrue(all(names))
+
+    def test_gsoc_example_1_display_id(self):
+        # See issue #240
+        collection = 'https://synbiohub.org/public/igem/igem_collection/1'
+        display_id = 'BBa_E0040'
+        query = sbol2.SearchQuery()
+        query[sbol2.SBOL_COLLECTION] = collection
+        query[sbol2.SBOL_DISPLAY_ID] = display_id
+        # GSOC is always looking for DNA Region
+        query[sbol2.SBOL_TYPES] = sbol2.BIOPAX_DNA
+        part_shop = sbol2.PartShop(GSOC_SBH_URL)
+        response = part_shop.search(query)
+        # At least one item in return should be the
+        # expected return: https://synbiohub.org/public/igem/BBa_E0040/1
+        identities = [r.identity for r in response]
+        self.assertIn('https://synbiohub.org/public/igem/BBa_E0040/1', identities)
+        #
+        # All items in response should have name == GFP exactly.
+        display_ids = [r.displayId == display_id for r in response]
+        self.assertTrue(all(display_ids))
 
 
 if __name__ == '__main__':

--- a/test/test_searchquery.py
+++ b/test/test_searchquery.py
@@ -54,6 +54,84 @@ class TestSearchQuery(unittest.TestCase):
         display_ids = [r.displayId == display_id for r in response]
         self.assertTrue(all(display_ids))
 
+    def gsoc_search_title(self, part_shop, collection, title):
+        query = sbol2.SearchQuery()
+        query[sbol2.SBOL_COLLECTION] = collection
+        query[sbol2.SBOL_NAME] = title
+        # GSOC is always looking for DNA Region
+        query[sbol2.SBOL_TYPES] = sbol2.BIOPAX_DNA
+        return part_shop.search(query)
+
+    def gsoc_search_display_id(self, part_shop, collection, display_id):
+        query = sbol2.SearchQuery()
+        query[sbol2.SBOL_COLLECTION] = collection
+        query[sbol2.SBOL_DISPLAY_ID] = display_id
+        # GSOC is always looking for DNA Region
+        query[sbol2.SBOL_TYPES] = sbol2.BIOPAX_DNA
+        return part_shop.search(query)
+
+    def do_gsoc_search(self, collection, term):
+        part_shop = sbol2.PartShop(GSOC_SBH_URL)
+        results = self.gsoc_search_title(part_shop, collection, term)
+        results.extend(self.gsoc_search_display_id(part_shop, collection, term))
+        return results
+
+    def test_gsoc_example_2(self):
+        # Looking for: https://synbiohub.org/public/igem/BBa_R0010/1
+        #              and/or https://synbiohub.org/public/igem/BBa_C0012/1
+        # Collection: https://synbiohub.org/public/igem/igem_collection/1
+        # Search term: "LacI"
+        # Don't want: https://synbiohub.org/public/igem/BBa_S03334/1
+        #             or https://synbiohub.org/public/igem/BBa_K1444015/1
+        collection = 'https://synbiohub.org/public/igem/igem_collection/1'
+        results = self.do_gsoc_search(collection,
+                                      'LacI')
+        identities = [r.identity for r in results]
+        self.assertIn('https://synbiohub.org/public/igem/BBa_R0010/1', identities)
+        # This item requires case-insensitive search. I don't see a way to do that.
+        # self.assertIn('https://synbiohub.org/public/igem/BBa_C0012/1', identities)
+        self.assertNotIn('https://synbiohub.org/public/igem/BBa_S03334/1', identities)
+        self.assertNotIn('https://synbiohub.org/public/igem/BBa_K1444015/1', identities)
+
+    def test_gsoc_example_3(self):
+        # Looking for: https://synbiohub.org/public/igem/BBa_R0010/1
+        # Collection: https://synbiohub.org/public/igem/igem_collection/1
+        # Search term: "BBa_R0010"
+        # Don't want: https://synbiohub.org/public/igem/BBa_S03334/1
+        #             or https://synbiohub.org/public/igem/BBa_K1444015/1
+        collection = 'https://synbiohub.org/public/igem/igem_collection/1'
+        results = self.do_gsoc_search(collection,
+                                      'BBa_R0010')
+        identities = [r.identity for r in results]
+        self.assertIn('https://synbiohub.org/public/igem/BBa_R0010/1', identities)
+        self.assertNotIn('https://synbiohub.org/public/igem/BBa_S03334/1', identities)
+        self.assertNotIn('https://synbiohub.org/public/igem/BBa_K1444015/1', identities)
+
+    def test_gsoc_example_4(self):
+        # Looking for: https://synbiohub.org/public/igem/BBa_B0034/1
+        # Collection: https://synbiohub.org/public/igem/igem_collection/1
+        # Search term: "BBa_B0034"
+        # Don't want: https://synbiohub.org/public/igem/BBa_I13617/1
+        collection = 'https://synbiohub.org/public/igem/igem_collection/1'
+        results = self.do_gsoc_search(collection,
+                                      'BBa_B0034')
+        identities = [r.identity for r in results]
+        self.assertIn('https://synbiohub.org/public/igem/BBa_B0034/1', identities)
+        self.assertNotIn('https://synbiohub.org/public/igem/BBa_I13617/1', identities)
+
+    def test_gsoc_example_5(self):
+        # Looking for: https://synbiohub.org/public/bsu/BO_28874/1
+        # Collection: https://synbiohub.org/public/bsu/bsu_collection/1
+        # Search term: "acca"
+        # Don't want: https://synbiohub.org/public/bsu/BO_26604/1
+        collection = 'https://synbiohub.org/public/bsu/bsu_collection/1'
+        results = self.do_gsoc_search(collection,
+                                      # If we can do case-insensitive, use 'acca'
+                                      'accA')
+        identities = [r.identity for r in results]
+        self.assertIn('https://synbiohub.org/public/bsu/BO_28874/1', identities)
+        self.assertNotIn('https://synbiohub.org/public/bsu/BO_26604/1', identities)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_searchquery.py
+++ b/test/test_searchquery.py
@@ -132,6 +132,17 @@ class TestSearchQuery(unittest.TestCase):
         self.assertIn('https://synbiohub.org/public/bsu/BO_28874/1', identities)
         self.assertNotIn('https://synbiohub.org/public/bsu/BO_26604/1', identities)
 
+    def test_gsoc_count_5(self):
+        part_shop = sbol2.PartShop(GSOC_SBH_URL)
+        query = sbol2.SearchQuery()
+        collection = 'https://synbiohub.org/public/bsu/bsu_collection/1'
+        query[sbol2.SBOL_COLLECTION] = collection
+        query[sbol2.SBOL_NAME] = 'accA'
+        # GSOC is always looking for DNA Region
+        query[sbol2.SBOL_TYPES] = sbol2.BIOPAX_DNA
+        count = part_shop.searchCount(query)
+        self.assertEqual(1, count)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_searchquery.py
+++ b/test/test_searchquery.py
@@ -1,0 +1,38 @@
+import unittest
+
+import sbol2
+
+
+GSOC_SBH_URL = 'https://synbiohub.org'
+
+
+class TestSearchQuery(unittest.TestCase):
+
+    def test_search_query1(self):
+        query = sbol2.SearchQuery()
+        query[sbol2.SBOL_ROLES] = sbol2.BIOPAX_DNA
+        self.assertIn(sbol2.SBOL_ROLES, query.properties)
+        self.assertEqual(sbol2.BIOPAX_DNA, query[sbol2.SBOL_ROLES])
+
+    def test_gsoc_example_1_title(self):
+        # See issue #240
+        collection = 'https://synbiohub.org/public/igem/igem_collection/1'
+        title = 'GFP'
+        query = sbol2.SearchQuery()
+        query[sbol2.SBOL_COLLECTION] = collection
+        query[sbol2.SBOL_NAME] = title
+        # GSOC is always looking for DNA Region
+        query[sbol2.SBOL_ROLES] = sbol2.BIOPAX_DNA
+        part_shop = sbol2.PartShop(GSOC_SBH_URL)
+        response = part_shop.search(query)
+        # At least one item in return should be the
+        # expected return: https://synbiohub.org/public/igem/BBa_E0040/1
+        #
+        # All items in response should have name == GFP exactly.
+
+        self.assertEqual(None, part_shop)
+        pass
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_searchquery.py
+++ b/test/test_searchquery.py
@@ -22,16 +22,17 @@ class TestSearchQuery(unittest.TestCase):
         query[sbol2.SBOL_COLLECTION] = collection
         query[sbol2.SBOL_NAME] = title
         # GSOC is always looking for DNA Region
-        query[sbol2.SBOL_ROLES] = sbol2.BIOPAX_DNA
+        query[sbol2.SBOL_TYPES] = sbol2.BIOPAX_DNA
         part_shop = sbol2.PartShop(GSOC_SBH_URL)
         response = part_shop.search(query)
         # At least one item in return should be the
         # expected return: https://synbiohub.org/public/igem/BBa_E0040/1
+        identities = [r.identity for r in response]
+        self.assertIn('https://synbiohub.org/public/igem/BBa_E0040/1', identities)
         #
         # All items in response should have name == GFP exactly.
-
-        self.assertEqual(None, part_shop)
-        pass
+        names = [r.name == title for r in response]
+        self.assertTrue(all(names))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This implements a `SearchQuery` object and allows it to be passed to `PartShop.search()` and `PartShop.searchCount()`. 

The unit tests in `test/test_searchquery.py` demonstrate how to use the `SearchQuery` object to make advanced searches.

Closes #240 
