### PR TITLE
Fix SBOLError calling order

### DIFF
--- a/sbol2/config.py
+++ b/sbol2/config.py
@@ -206,14 +206,14 @@ class Config:
             return
         if option not in options:
             msg = '{!r} is not a valid configuration option'.format(option)
-            raise SBOLError(msg, SBOLErrorCode.SBOL_ERROR_INVALID_ARGUMENT)
+            raise SBOLError(SBOLErrorCode.SBOL_ERROR_INVALID_ARGUMENT, msg)
         if option in valid_options:
             if val in valid_options[option]:
                 options[option] = val
             else:
                 msg = '{!r} is not a valid value for option {!r}.'.format(val, option)
                 msg += ' Valid options are: {!r}.'.format(valid_options[option])
-                raise SBOLError(msg, SBOLErrorCode.SBOL_ERROR_INVALID_ARGUMENT)
+                raise SBOLError(SBOLErrorCode.SBOL_ERROR_INVALID_ARGUMENT, msg)
         else:
             # Any argument is valid, eg. uriPrefix
             options[option] = val

--- a/sbol2/config.py
+++ b/sbol2/config.py
@@ -236,7 +236,7 @@ class Config:
             return options[option]
         else:
             msg = '{!r} is not a valid configuration option'.format(option)
-            raise SBOLError(msg, SBOLErrorCode.SBOL_ERROR_INVALID_ARGUMENT)
+            raise SBOLError(SBOLErrorCode.SBOL_ERROR_INVALID_ARGUMENT, msg)
 
 
 # Global methods

--- a/sbol2/document.py
+++ b/sbol2/document.py
@@ -640,7 +640,7 @@ class Document(Identified):
                 self.logger.debug('Found %d good references', len(matches))
                 if len(matches) > 1:
                     msg = 'Invalid custom annotation object in SBOL document'
-                    raise SBOLError(msg, SBOLErrorCode.SBOL_ERROR_SERIALIZATION)
+                    raise SBOLError(SBOLErrorCode.SBOL_ERROR_SERIALIZATION, msg)
                 if len(matches) == 1:
                     match = matches[0]
                     if property_uri not in match.owned_objects:
@@ -952,10 +952,10 @@ class Document(Identified):
         # Or if response['result'] is not empty?
         if response['errors'][0]:
             msg = ' '.join(response['errors'])
-            raise SBOLError(msg, SBOLErrorCode.SBOL_ERROR_INVALID_ARGUMENT)
+            raise SBOLError(SBOLErrorCode.SBOL_ERROR_INVALID_ARGUMENT, msg)
         if not response['result']:
             msg = 'Validator returned no content'
-            raise SBOLError(msg, SBOLErrorCode.SBOL_ERROR_INVALID_ARGUMENT)
+            raise SBOLError(SBOLErrorCode.SBOL_ERROR_INVALID_ARGUMENT, msg)
         # write the result to the desired output path
         with open(output_path, 'w') as fp:
             fp.write(response['result'])

--- a/sbol2/document.py
+++ b/sbol2/document.py
@@ -213,10 +213,10 @@ class Document(Identified):
         # Check for uniqueness of URI
         identity_uri = sbol_obj.identity
         if identity_uri in self.SBOLObjects:
-            raise SBOLError('Cannot add ' + sbol_obj.identity +
+            raise SBOLError(SBOLErrorCode.SBOL_ERROR_URI_NOT_UNIQUE,
+                            'Cannot add ' + sbol_obj.identity +
                             ' to Document. An object with this identity '
-                            'is already contained in the Document',
-                            SBOLErrorCode.SBOL_ERROR_URI_NOT_UNIQUE)
+                            'is already contained in the Document')
         else:
             # If TopLevel add to Document.
             if sbol_obj.is_top_level():
@@ -358,8 +358,8 @@ class Document(Identified):
         try:
             return self.SBOLObjects[uri]
         except KeyError:
-            raise SBOLError(f'Object {uri} was not found',
-                            SBOLErrorCode.SBOL_ERROR_NOT_FOUND)
+            raise SBOLError(SBOLErrorCode.SBOL_ERROR_NOT_FOUND,
+                            f'Object {uri} was not found')
 
     def getAll(self):
         """
@@ -917,7 +917,7 @@ class Document(Identified):
         if uri not in self.SBOLObjects:
             msg = 'Top level object {} is not in document'
             msg = msg.format(uri)
-            raise SBOLError(msg, SBOLErrorCode.SBOL_ERROR_NOT_FOUND)
+            raise SBOLError(SBOLErrorCode.SBOL_ERROR_NOT_FOUND, msg)
         sbol_obj = self.SBOLObjects[uri]
         # Verify object is top level
         if sbol_obj.is_top_level():
@@ -925,7 +925,7 @@ class Document(Identified):
         # Not top level, raise error
         msg = '{} is not a top level object'
         msg = msg.format(uri)
-        raise SBOLError(msg, SBOLErrorCode.SBOL_ERROR_INVALID_ARGUMENT)
+        raise SBOLError(SBOLErrorCode.SBOL_ERROR_INVALID_ARGUMENT, msg)
 
     def copy(self, target_namespace=None, target_doc=None, version=None):
         # This enables the user to use the pattern doc2 = doc.copy() to clone a Document.
@@ -1040,7 +1040,7 @@ def validate(doc: Document, options: Mapping[str, Any]):
     else:
         msg = 'Validation failure. HTTP post request failed with code {}: {}'
         msg = msg.format(response.status_code, response.content)
-        raise SBOLError(msg, SBOLErrorCode.SBOL_ERROR_BAD_HTTP_REQUEST)
+        raise SBOLError(SBOLErrorCode.SBOL_ERROR_BAD_HTTP_REQUEST, msg)
 
 
 igem_assembly_scars = '''<?xml version="1.0" encoding="utf-8"?>

--- a/sbol2/identified.py
+++ b/sbol2/identified.py
@@ -161,10 +161,10 @@ class Identified(SBOLObject):
         if parent.doc:
             matches = parent.doc.find_property_value(SBOL_IDENTITY, self.identity)
             if len(matches) > 0:
-                raise SBOLError("Cannot update SBOL-compliant URI. "
+                raise SBOLError(SBOLErrorCode.SBOL_ERROR_URI_NOT_UNIQUE,
+                                "Cannot update SBOL-compliant URI. "
                                 "An object with URI " + str(self.identity) +
-                                " is already in the Document",
-                                SBOLErrorCode.SBOL_ERROR_URI_NOT_UNIQUE)
+                                " is already in the Document")
 
     def copy(self, target_doc=None, target_namespace=None, version=None):
 

--- a/sbol2/identified.py
+++ b/sbol2/identified.py
@@ -150,9 +150,9 @@ class Identified(SBOLObject):
             # Check for uniqueness of URI in local object properties
             matches = parent.find_property_value(SBOL_IDENTIFIED, obj_id)
             if len(matches) > 0:
-                raise SBOLError("Cannot update SBOL-compliant URI. The URI " +
-                                str(self.identity) + " is not unique",
-                                SBOLErrorCode.SBOL_ERROR_URI_NOT_UNIQUE)
+                raise SBOLError(SBOLErrorCode.SBOL_ERROR_URI_NOT_UNIQUE,
+                                "Cannot update SBOL-compliant URI. The URI " +
+                                str(self.identity) + " is not unique")
             for rdf_type, store in self.owned_objects.items():
                 if rdf_type not in self._hidden_properties:
                     for nested_obj in store:

--- a/sbol2/object.py
+++ b/sbol2/object.py
@@ -287,8 +287,8 @@ class SBOLObject:
             return [str(x) for x in self.properties[property_uri]]
         except KeyError as e:
             # no property by this name
-            raise SBOLError('Property {} not found'.format(property_uri),
-                            SBOLErrorCode.SBOL_ERROR_NOT_FOUND)
+            raise SBOLError(SBOLErrorCode.SBOL_ERROR_NOT_FOUND,
+                            'Property {} not found'.format(property_uri))
 
     def getProperties(self):
         """Gets URIs for all properties contained by this object.

--- a/sbol2/partshop.py
+++ b/sbol2/partshop.py
@@ -244,7 +244,7 @@ class PartShop:
             return uri.replace(self.spoofed_resource, self.resource)
         msg = ('{} does not exist in the resource namespace')
         msg = msg.format(uri)
-        raise SBOLError(msg, SBOLErrorCode.SBOL_ERROR_INVALID_ARGUMENT)
+        raise SBOLError(SBOLErrorCode.SBOL_ERROR_INVALID_ARGUMENT, msg)
 
     def remove(self, uri):
         query = self._uri2url(uri)
@@ -256,13 +256,13 @@ class PartShop:
         response = requests.get(url, headers=headers)
         if response.ok:
             return True
-        if response.status_code == 401:
-            # TODO: Is there a symbol we can use instead of 401?
+        if response.status_code == requests.codes.unauthorized:
+            # Handle a 401 Unauthorized error
             msg = 'You must login with valid credentials before removing'
-            raise SBOLError(msg, SBOLErrorCode.SBOL_ERROR_HTTP_UNAUTHORIZED)
+            raise SBOLError(SBOLErrorCode.SBOL_ERROR_HTTP_UNAUTHORIZED, msg)
         # Not sure what went wrong
         msg = 'Unknown error: ' + response
-        raise SBOLError(msg, SBOLErrorCode.SBOL_ERROR_BAD_HTTP_REQUEST)
+        raise SBOLError(SBOLErrorCode.SBOL_ERROR_BAD_HTTP_REQUEST, msg)
 
     def login(self, user_id, password=''):
         """In order to submit to a PartShop, you must login first.
@@ -283,7 +283,7 @@ class PartShop:
         if not response:
             msg = 'Login failed due to an HTTP error: {}'
             msg = msg.format(response)
-            raise SBOLError(msg, SBOLErrorCode.SBOL_ERROR_BAD_HTTP_REQUEST)
+            raise SBOLError(SBOLErrorCode.SBOL_ERROR_BAD_HTTP_REQUEST, msg)
         self.key = response.content.decode('utf-8')
         return response
 

--- a/sbol2/partshop.py
+++ b/sbol2/partshop.py
@@ -50,7 +50,7 @@ class PartShop:
         if not isinstance(url, str):
             msg = ('PartShop initialization failed. The {} URL '
                    + 'is not of type string').format(url_name)
-            raise SBOLError(msg, SBOLErrorCode.SBOL_ERROR_INVALID_ARGUMENT)
+            raise SBOLError(SBOLErrorCode.SBOL_ERROR_INVALID_ARGUMENT, msg)
         # Authenticity check with urlparse as to ensure correct scheme and
         # netloc present
         url_pieces = urllib.parse.urlparse(url)
@@ -58,13 +58,13 @@ class PartShop:
                    url_pieces.netloc]):
             msg = ('PartShop initialization failed. The {} URL '
                    + 'was not valid').format(url_name)
-            raise SBOLError(msg, SBOLErrorCode.SBOL_ERROR_INVALID_ARGUMENT)
+            raise SBOLError(SBOLErrorCode.SBOL_ERROR_INVALID_ARGUMENT, msg)
         # String check to ensure length > 0 and does not contain terminal "/"
         if len(url) > 0 and url[-1] == '/':
             msg = ('PartShop initialization failed. The {} URL '
                    + 'should not contain a terminal forward slash')
             msg = msg.format(url_name)
-            raise SBOLError(msg, SBOLErrorCode.SBOL_ERROR_INVALID_ARGUMENT)
+            raise SBOLError(SBOLErrorCode.SBOL_ERROR_INVALID_ARGUMENT, msg)
         return url
 
     @property
@@ -149,13 +149,13 @@ class PartShop:
                                     headers={'X-authorization': self.key,
                                              'Accept': 'text/plain'})
             if response.status_code == 404:
-                raise SBOLError('Part not found. Unable to pull: ' + query,
-                                SBOLErrorCode.SBOL_ERROR_NOT_FOUND,)
+                raise SBOLError(SBOLErrorCode.SBOL_ERROR_NOT_FOUND,
+                                'Part not found. Unable to pull: ' + query)
             elif response.status_code == 401:
-                raise SBOLError('Please log in with valid credentials',
-                                SBOLErrorCode.SBOL_ERROR_HTTP_UNAUTHORIZED,)
+                raise SBOLError(SBOLErrorCode.SBOL_ERROR_HTTP_UNAUTHORIZED,
+                                'Please log in with valid credentials')
             elif not response:
-                raise SBOLError(response, SBOLErrorCode.SBOL_ERROR_BAD_HTTP_REQUEST)
+                raise SBOLError(SBOLErrorCode.SBOL_ERROR_BAD_HTTP_REQUEST, response)
             # Add content to document
             doc.readString(response.content)
             doc.resource_namespaces.add(self.resource)
@@ -338,11 +338,11 @@ class PartShop:
         if response.status_code == http.HTTPStatus.UNAUTHORIZED:
             # HTTP 401
             msg = 'You must login with valid credentials before attaching a file'
-            raise SBOLError(msg, SBOLErrorCode.SBOL_ERROR_HTTP_UNAUTHORIZED)
+            raise SBOLError(SBOLErrorCode.SBOL_ERROR_HTTP_UNAUTHORIZED, msg)
         # Not sure what went wrong
         msg = 'HTTP Error code {} trying to attach file.'
         msg = msg.format(response.status_code)
-        raise SBOLError(msg, SBOLErrorCode.SBOL_ERROR_BAD_HTTP_REQUEST)
+        raise SBOLError(SBOLErrorCode.SBOL_ERROR_BAD_HTTP_REQUEST, msg)
 
     def _make_search_item(self, item: dict) -> Identified:
         obj = Identified()
@@ -367,7 +367,7 @@ class PartShop:
         response = requests.get(url, headers=headers)
         if not response:
             # Something went wrong
-            raise SBOLError(response, SBOLErrorCode.SBOL_ERROR_BAD_HTTP_REQUEST)
+            raise SBOLError(SBOLErrorCode.SBOL_ERROR_BAD_HTTP_REQUEST, response)
         # Everything looks good, parse and return the results
         return [self._make_search_item(item) for item in (response.json())]
 
@@ -447,7 +447,7 @@ class PartShop:
         response = requests.get(url, headers=headers)
         if not response:
             # Something went wrong
-            raise SBOLError(response, SBOLErrorCode.SBOL_ERROR_BAD_HTTP_REQUEST)
+            raise SBOLError(SBOLErrorCode.SBOL_ERROR_BAD_HTTP_REQUEST, response)
         # Everything looks good, parse and return the results
         return int(response.text)
 

--- a/sbol2/property.py
+++ b/sbol2/property.py
@@ -623,10 +623,10 @@ class OwnedObject(Property):
         # See issue #127
         for obj in object_store:
             if obj.identity == sbol_obj.identity:
-                raise SBOLError("The object " + sbol_obj.identity +
+                raise SBOLError(SBOLErrorCode.SBOL_ERROR_URI_NOT_UNIQUE,
+                                "The object " + sbol_obj.identity +
                                 " is already contained by the " +
-                                self._rdf_type + " property",
-                                SBOLErrorCode.SBOL_ERROR_URI_NOT_UNIQUE)
+                                self._rdf_type + " property")
         # Add to parent object
         object_store.append(sbol_obj)
         # Run validation rules
@@ -699,7 +699,7 @@ class OwnedObject(Property):
                 return obj
             else:
                 msg = 'Object {} not found'.format(id)
-                raise SBOLError(msg, SBOLErrorCode.NOT_FOUND_ERROR)
+                raise SBOLError(SBOLErrorCode.NOT_FOUND_ERROR, msg)
 
     def find_persistent_identity(self, search_uri):
         if not Config.getOption(ConfigOptions.SBOL_COMPLIANT_URIS):

--- a/sbol2/property.py
+++ b/sbol2/property.py
@@ -169,8 +169,8 @@ class Property(ABC):
             if self._rdf_type in self._sbol_owner.properties:
                 properties = self._sbol_owner.properties[self._rdf_type]
                 if index >= len(properties):
-                    raise SBOLError('Index out of range',
-                                    SBOLErrorCode.SBOL_ERROR_INVALID_ARGUMENT)
+                    raise SBOLError(SBOLErrorCode.SBOL_ERROR_INVALID_ARGUMENT,
+                                    'Index out of range')
                 if len(properties) == 1:
                     self.clear()
                 else:
@@ -608,10 +608,10 @@ class OwnedObject(Property):
         # Not top level, add to the attribute
         object_store = self._sbol_owner.owned_objects[self._rdf_type]
         if sbol_obj in object_store:
-            raise SBOLError("The object " + sbol_obj.identity +
+            raise SBOLError(SBOLErrorCode.SBOL_ERROR_URI_NOT_UNIQUE,
+                            "The object " + sbol_obj.identity +
                             " is already contained by the " +
-                            self._rdf_type + " property",
-                            SBOLErrorCode.SBOL_ERROR_URI_NOT_UNIQUE)
+                            self._rdf_type + " property")
         # Add to Document and check for uniqueness of URI
         if self._sbol_owner.doc is not None:
             sbol_obj.doc = self._sbol_owner.doc
@@ -790,11 +790,11 @@ class OwnedObject(Property):
         if len(self._sbol_owner.owned_objects[rdf_type]) == 0:
             self._sbol_owner.owned_objects[rdf_type].append(sbol_obj)
         else:
-            raise SBOLError("Cannot set " + parsePropertyName(rdf_type) +
+            raise SBOLError(SBOLErrorCode.SBOL_ERROR_INVALID_ARGUMENT,
+                            "Cannot set " + parsePropertyName(rdf_type) +
                             " property. The property is already set. "
                             "Call remove before attempting to "
-                            "overwrite the value.",
-                            SBOLErrorCode.SBOL_ERROR_INVALID_ARGUMENT)
+                            "overwrite the value.")
         sbol_obj.parent = self._sbol_owner
         # Update URI for the argument object and all its children,
         # if SBOL-compliance is enabled.
@@ -883,8 +883,8 @@ class OwnedObject(Property):
             if self._rdf_type in self._sbol_owner.owned_objects:
                 object_store = self._sbol_owner.owned_objects[self._rdf_type]
                 if index >= len(object_store):
-                    raise SBOLError("Index out of range",
-                                    SBOLErrorCode.SBOL_ERROR_INVALID_ARGUMENT)
+                    raise SBOLError(SBOLErrorCode.SBOL_ERROR_INVALID_ARGUMENT,
+                                    "Index out of range")
                 obj = object_store[index]
                 if self._sbol_owner.getTypeURI() == SBOL_DOCUMENT:
                     del obj.doc.SBOLObjects[rdflib.URIRef(obj.identity)]

--- a/sbol2/sbolerror.py
+++ b/sbol2/sbolerror.py
@@ -25,7 +25,7 @@ class SBOLErrorCode(Enum):
 
 class SBOLError(Exception):
 
-    def __init__(self, message, err):
+    def __init__(self, err, message):
         if isinstance(message, SBOLErrorCode):
             warnings.warn("SBOLError arguments out of order",
                           RuntimeWarning)

--- a/sbol2/sequence.py
+++ b/sbol2/sequence.py
@@ -143,10 +143,10 @@ class Sequence(TopLevel):
                     parent_cdef.find_property_value(SBOL_COMPONENT_PROPERTY, c.identity)
 
                 if len(sequence_annotations) > 1:
-                    raise SBOLError('Cannot compile Sequence. Component <%s> is '
+                    raise SBOLError(SBOLErrorCode.SBOL_ERROR_INVALID_ARGUMENT,
+                                    'Cannot compile Sequence. Component <%s> is '
                                     'irregular. More than one SequenceAnnotation is '
-                                    'associated with this Component' % c.identity,
-                                    SBOLErrorCode.SBOL_ERROR_INVALID_ARGUMENT)
+                                    'associated with this Component' % c.identity)
 
                 # Auto-construct a SequenceAnnotation for this Component if one doesn't
                 # already exist
@@ -186,10 +186,10 @@ class Sequence(TopLevel):
                     r = sa.locations.createRange(range_id + '_range')
                     ranges.append(r)
                 if len(ranges) > 1:
-                    raise SBOLError('Cannot compile Sequence <%s> because '
+                    raise SBOLError(SBOLErrorCode.SBOL_ERROR_INVALID_ARGUMENT,
+                                    'Cannot compile Sequence <%s> because '
                                     'SequenceAnnotation <%s> has more than one Range.'
-                                    % (self.identity, sa.identity),
-                                    SBOLErrorCode.SBOL_ERROR_INVALID_ARGUMENT)
+                                    % (self.identity, sa.identity))
 
                 r = ranges[0]
                 r.start = len(composite_sequence) + 1

--- a/test/test_error.py
+++ b/test/test_error.py
@@ -10,16 +10,16 @@ class TestError(unittest.TestCase):
         # called with arguments in the wrong order. A warning has been
         # added to note these occurrences until they can be fixed.
         with self.assertWarns(RuntimeWarning):
-            sbol2.SBOLError(sbol2.SBOLErrorCode.NOT_FOUND_ERROR,
-                            'Item not found')
+            sbol2.SBOLError('Item not found',
+                            sbol2.SBOLErrorCode.NOT_FOUND_ERROR)
 
     def test_what(self):
         msg = 'Item not found'
-        error = sbol2.SBOLError(msg, sbol2.SBOLErrorCode.NOT_FOUND_ERROR)
+        error = sbol2.SBOLError(sbol2.SBOLErrorCode.NOT_FOUND_ERROR, msg)
         self.assertEqual(error.what(), msg)
 
     def test_error_code(self):
         msg = 'Item not found'
         code = sbol2.SBOLErrorCode.NOT_FOUND_ERROR
-        error = sbol2.SBOLError(msg, code)
+        error = sbol2.SBOLError(code, msg)
         self.assertEqual(error.error_code(), code)


### PR DESCRIPTION
Make all calls to SBOLError be `SBOLError(code, message)`.

The original pySBOL2 code changed the order of arguments to SBOLError.
When code was ported from pySBOL it has arguments in a different order.
A patch fix was put in place to detect arguments out of order, issue
a runtime warning, and fix the order. That left a mix of argument
ordering.

Now we are migrating to code that has the arguments in the same order
as pySBOL. This first wave fixes all the SBOLError calls that are part
of the unit tests.

Fixes #80 