### PR TITLE
350 register ownership predicates

### DIFF
--- a/sbol2/SBOL2Serialize.py
+++ b/sbol2/SBOL2Serialize.py
@@ -33,27 +33,13 @@ from rdflib import URIRef, Literal
 rdfNS = "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 sbolNS = "http://sbols.org/v2#"
 
+OWNERSHIP_PREDICATES = set()
+
 
 def is_ownership_relation(g, triple):
     subject = triple[0].toPython()
     predicate = triple[1].toPython()
     obj = triple[2]
-
-    ownership_predicates = {
-        sbolNS + 'module',
-        sbolNS + 'mapsTo',
-        sbolNS + 'interaction',
-        sbolNS + 'participation',
-        sbolNS + 'functionalComponent',
-        sbolNS + 'sequenceConstraint',
-        sbolNS + 'location',
-        sbolNS + 'sourceLocation',
-        sbolNS + 'sequenceAnnotation',
-        sbolNS + 'measure'
-    }
-
-    if predicate in ownership_predicates:
-        return True
 
     # SBOL2 reuses the "component" predicate as both an ownership predicate (in
     # the case of ComponentDefinition) and a referencing one (in the case of
@@ -65,6 +51,8 @@ def is_ownership_relation(g, triple):
         else:
             return True
 
+    if predicate in OWNERSHIP_PREDICATES:
+        return True
     return False
 
 

--- a/sbol2/SBOL2Serialize.py
+++ b/sbol2/SBOL2Serialize.py
@@ -22,6 +22,8 @@
 #   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
 #   OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 #   SUCH DAMAGE.
+from collections import defaultdict
+from typing import Dict
 
 from lxml import etree
 from lxml.etree import tostring
@@ -36,13 +38,13 @@ sbolNS = "http://sbols.org/v2#"
 # This is a module global that is used to register ownership relationships
 # between classes. The serializer uses this to generate structured XML from
 # flat RDF/XML
-OWNERSHIP_PREDICATES = {}
+OWNERSHIP_PREDICATES: Dict[URIRef, list] = defaultdict(list)
 
 
 def is_ownership_relation(g, triple):
     subject = triple[0]
     predicate = triple[1]
-    obj = triple[2]
+    # object = triple[2]
 
     if predicate not in OWNERSHIP_PREDICATES:
         return False
@@ -51,8 +53,9 @@ def is_ownership_relation(g, triple):
     # the case of ComponentDefinition) and a referencing one (in the case of
     # SequenceAnnotation). This case requires we check the OWNERSHIP_PREDICATES
     # register
-    if (subject, RDF.type, OWNERSHIP_PREDICATES[predicate]) in g:
-        return True
+    for parent_type in OWNERSHIP_PREDICATES[predicate]:
+        if (subject, RDF.type, parent_type) in g:
+            return True
     return False
 
 
@@ -61,7 +64,7 @@ def register_ownership_relation(parent_type, predicate):
     #
     # :param parent_type: The RDF type of the parent class
     # :param predicate: The URI for the property.
-    OWNERSHIP_PREDICATES[URIRef(predicate)] = URIRef(parent_type)
+    OWNERSHIP_PREDICATES[URIRef(predicate)].append(URIRef(parent_type))
 
 
 def ns_prefix_dict(g):

--- a/sbol2/document.py
+++ b/sbol2/document.py
@@ -766,7 +766,7 @@ class Document(Identified):
             self.graph.bind(prefix, ns)
         # ASSUMPTION: Document does not have properties. Is this a valid assumption?
         for obj in self.SBOLObjects.values():
-            obj.build_graph(self.graph, SBOL2Serialize.OWNERSHIP_PREDICATES)
+            obj.build_graph(self.graph)
         if self.logger.isEnabledFor(logging.DEBUG):
             for s, p, o in self.graph:
                 self.logger.debug('Graph contains: %r', (s, p, o))

--- a/sbol2/document.py
+++ b/sbol2/document.py
@@ -766,7 +766,7 @@ class Document(Identified):
             self.graph.bind(prefix, ns)
         # ASSUMPTION: Document does not have properties. Is this a valid assumption?
         for obj in self.SBOLObjects.values():
-            obj.build_graph(self.graph)
+            obj.build_graph(self.graph, SBOL2Serialize.OWNERSHIP_PREDICATES)
         if self.logger.isEnabledFor(logging.DEBUG):
             for s, p, o in self.graph:
                 self.logger.debug('Graph contains: %r', (s, p, o))

--- a/sbol2/object.py
+++ b/sbol2/object.py
@@ -387,7 +387,7 @@ class SBOLObject:
         """
         raise NotImplementedError("Implemented by child classes")
 
-    def build_graph(self, graph):
+    def build_graph(self, graph, ownership_predicates):
         graph.add((rdflib.URIRef(self.identity),
                    rdflib.RDF.type,
                    rdflib.URIRef(self.rdf_type)))
@@ -406,11 +406,12 @@ class SBOLObject:
             if typeURI in self._hidden_properties:
                 # Skip hidden properties
                 continue
+            ownership_predicates.add(typeURI)  # used in SBOL2Serialize to structure XML
             for owned_obj in objlist:
                 graph.add((rdflib.URIRef(self.identity),
                            rdflib.URIRef(typeURI),
                            URIRef(owned_obj.identity)))
-                owned_obj.build_graph(graph)
+                owned_obj.build_graph(graph, ownership_predicates)
 
     def __str__(self):
         return self.identity

--- a/sbol2/object.py
+++ b/sbol2/object.py
@@ -14,6 +14,7 @@ from .property import Property, OwnedObject, URIProperty
 from .sbolerror import SBOLError
 from .sbolerror import SBOLErrorCode
 from .uridict import URIDict
+from . import SBOL2Serialize
 from . import validation
 
 
@@ -387,7 +388,7 @@ class SBOLObject:
         """
         raise NotImplementedError("Implemented by child classes")
 
-    def build_graph(self, graph, ownership_predicates):
+    def build_graph(self, graph):
         graph.add((rdflib.URIRef(self.identity),
                    rdflib.RDF.type,
                    rdflib.URIRef(self.rdf_type)))
@@ -406,12 +407,16 @@ class SBOLObject:
             if typeURI in self._hidden_properties:
                 # Skip hidden properties
                 continue
-            ownership_predicates.add(typeURI)  # used in SBOL2Serialize to structure XML
+
             for owned_obj in objlist:
                 graph.add((rdflib.URIRef(self.identity),
                            rdflib.URIRef(typeURI),
                            URIRef(owned_obj.identity)))
-                owned_obj.build_graph(graph, ownership_predicates)
+                owned_obj.build_graph(graph)
+
+            # register ownership relationship in SBOL2Serialize to structure XML
+            SBOL2Serialize.register_ownership_relation(self.getTypeURI(),
+                                                       typeURI)
 
     def __str__(self):
         return self.identity

--- a/sbol2/searchquery.py
+++ b/sbol2/searchquery.py
@@ -19,7 +19,8 @@ class SearchQuery(TopLevel):
         self.persistentIdentity = ''
         self.version = ''
         # Add some attributes
-        self.objectType = URIProperty(self, OBJECT_TYPE_URI, '0', '1', None, search_target)
+        self.objectType = URIProperty(self, OBJECT_TYPE_URI, '0', '1', None,
+                                      search_target)
         self.offset = IntProperty(self, OFFSET_URI, '0', '1', None, offset)
         self.limit = IntProperty(self, LIMIT_URI, '0', '1', None, limit)
 


### PR DESCRIPTION
- Owned object relationships are no longer hard-coded in the serializer
- Introduces a global OWNERSHIP_PREDICATES in the serializer
- Owned object relationships are now extensible
- Fix #350 
