### PR TITLE
Document how to use PyPy with pySBOL2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,10 @@ matrix:
     python: 3.6
   - os: linux
     language: python
-    python: 3.7
+    python: 3.8
   - os: linux
     language: python
-    python: 3.8
+    python: pypy3
   - os: windows
     language: shell
     before_install:

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -105,3 +105,28 @@ install Python 3 before installing pySBOL2. You can download the
 latest Python 3 release from `python.org
 <https://www.python.org>`_. After Python 3 is installed please follow
 the instructions above to install pySBOL2.
+
+Using PyPy
+----------------------
+
+`PyPy <https://www.pypy.org>`_ is "a fast, compliant alternative
+implementation of Python." PyPy uses a
+`just-in-time compiler <https://en.wikipedia.org/wiki/Just-in-time_compilation>`_
+(JIT), which can make certain programs faster.
+
+pySBOL2 uses `RDFlib <https://github.com/RDFLib/rdflib>`_ which can be
+slow for reading and writing SBOL files when compared to a C
+implementation like `Raptor <http://librdf.org/raptor/>`_ .
+
+Programs that might benefit from PyPy's JIT are programs that have
+longer runtimes and repeat tasks. A program that iterates over a
+directory reading each SBOL file, modifying the contents, and then
+writing the file is a good example of a program that might benefit
+from PyPy's JIT. On the other hand a program that reads or writes a
+single file is an example of a program that would probably *not*
+benefit from PyPy because the JIT complier doesn't have a chance to
+optimize the code.
+
+pySBOL2 is compatible with PyPy. The installation and use of PyPy is
+out of scope for this document. Please see the PyPy documentation if
+you want to try using PyPy with pySBOL2.


### PR DESCRIPTION
* Add a PyPy build to Travis to confirm and maintain PyPy 3 compatibility
* Add a PyPy section to the documentation explaining what PyPy is, why it might be useful, and a pointer to installation and usage information

Closes #279 