### PR TITLE
Travis build improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,12 +16,12 @@ matrix:
   - os: windows
     language: shell
     before_install:
-    - choco install python3 --version=3.7.6 --no-progress -y
+    - choco install python3 --version=3.8.5 --no-progress -y
     install:
-    - C:\\Python37\\python -m pip install .
-    - C:\\Python37\\python -m pip install 'pycodestyle>=2.6.0'
+    - C:\\Python38\\python -m pip install .
+    - C:\\Python38\\python -m pip install 'pycodestyle>=2.6.0'
     script:
-    - C:\\Python37\\python -m unittest discover -s test
+    - C:\\Python38\\python -m unittest discover -s test
 install:
   - python3 -m pip install .
   - python3 -m pip install 'pycodestyle>=2.6.0'

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,15 @@ language: generic
 matrix:
   include:
   - os: linux
+    dist: bionic
     language: python
     python: 3.6
   - os: linux
+    dist: bionic
     language: python
     python: 3.8
   - os: linux
+    dist: bionic
     language: python
     python: pypy3
   - os: windows

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
   - python3 -m pip install .
   - python3 -m pip install 'pycodestyle>=2.6.0'
 script:
-  - travis_wait python3 -m unittest discover -s test
+  - python3 -m unittest discover -s test
 env:
   global:
   - secure: jRx84QQzMJ/A/Vke0301kuNtiztnUpu2RbQk909eiOEIZZR/0asV1EQybzr/dD2fVCokiCwXjghGD5r8BEOWk1moPWVRGYpJmdSZsYFZQn3cDg7TjzvU40vmHBeCdr64kP1DmZ2WcaMUtB/GAti3rUXDfbVsCe2Qsb7LsrrtXBlbb/jLIGIgO4Q2Bg/bR6ixFaiiWwxDkSR90yIJwhN14cNxgKge9uYdseQeUo0MuvItcZaNLo4ed7qZNa9POGpooHgcWOzSQug+YmVgGEIJ+pAUU+YZl4Sq1EVA7vJh51R65hgmsdisziffFWtzYlrpRPL7MR+anDibBNlMI97BQpt0+RyTEBvkTEojOGKlwj9QRa15ihW3vCffpq1zE7uccugYgqvAgqCeD3IN9uEccbDbEi/zFO1D9mIlsi5xFo3pIT+hmS67JTngh9ZKOmueMCbLZV575fvXO5uMiIIZezZMfm0VO9HE841K8jtY6T6fHsmyxwC745+MM2wpeV0rz1rD1PqcYF1Lxr8bOYny0wXBB9Gk2uAm2Uw2WSh+fZ5sdGCvLgeqzrEdLqb0aPe0vEu7NYfEp/p5BqeYsWvLhAJYDvsRldod/CPyS/cFPANdrk4Wg2acShrNR4U+PY8FRnOS5WWpABFYWi9s1Db6YsGLmRFDkG7ZBrhWSuKzDJM=


### PR DESCRIPTION
* Change from Ubuntu 16.04 Xenial to Ubuntu 18.04 Bionic
  * Ubuntu 20.04 Focal does not appear to be an option yet
  * Ubuntu 16.04 is still the default
* Change the Windows build to Python 3.8.5
  * This was Python 3.7.x
* Remove the unnecessary `travis_wait`
  * Our builds take far less than the 10 minute limit, so we shouldn't need this option