### PR TITLE
Clear out the document in append

### DIFF
--- a/sbol2/document.py
+++ b/sbol2/document.py
@@ -459,12 +459,12 @@ class Document(Identified):
         :return: None
         """
         self.logger.debug("Appending data from file: " + filename)
-        if not self.graph:
-            self.graph = rdflib.Graph()
-        # Save any changes we've made to the graph.
+        # Write our SBOL objects to an RDFlib graph
         self.update_graph()
         # Use rdflib to automatically merge the graphs together
         self.graph.parse(filename, format="application/rdf+xml")
+        # Clear out the SBOL objects, but not the newly merged graph
+        self.clear(clear_graph=False)
         # Base our internal representation on the new graph.
         self.parse_all()
 

--- a/test/test_document.py
+++ b/test/test_document.py
@@ -602,6 +602,22 @@ class TestDocumentExtensionObjects(unittest.TestCase):
         cd = doc.componentDefinitions[cd_uri]
         self.assertEqual(1, len(cd.roles))
 
+    def test_idempotent_read2(self):
+        doc = sbol2.Document()
+        doc.read(CRISPR_LOCATION)
+        old_doc_len = len(doc)
+        cd_uri = 'http://sbols.org/CRISPR_Example/gRNA_b/1.0.0'
+        cd = doc.componentDefinitions['http://sbols.org/CRISPR_Example/gRNA_b/1.0.0']
+        cd.components.create('c')
+        old_component_len = len(cd.components)
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            temp_file = os.path.join(tmpdirname, 'test.xml')
+            doc.write(temp_file)
+            doc.append(temp_file)
+        cd = doc.componentDefinitions[cd_uri]
+        self.assertEqual(old_component_len, len(cd.components))
+        self.assertEqual(old_doc_len, len(doc))
+
     def test_write_validation(self):
         # Test that write performs validation if requested
         # and skips validation if requested.


### PR DESCRIPTION
When appending, let RDFlib to the work of merging, then clear out
the SBOL objects and reload from the merged graph.

Fixes #362 