### PR TITLE
Mark Config.register_extension_class as a @staticmethod

### DIFF
--- a/sbol2/config.py
+++ b/sbol2/config.py
@@ -105,6 +105,7 @@ class Config:
     # extension classes with RDFtypes not part of the core specification
     SBOL_DATA_MODEL_REGISTER = {}
 
+    @staticmethod
     def register_extension_class(builder, type_uri):
         """Register an extension class and its namespace, so custom data
         can be embedded into and read from SBOL files.


### PR DESCRIPTION
Not sure how this was working, it was defined as a regular method instead
of a static method.