### PR TITLE
Control how Document.append merges and/or overwrites

### DIFF
--- a/sbol2/document.py
+++ b/sbol2/document.py
@@ -421,7 +421,7 @@ class Document(Identified):
         :return: None
         """
         self.clear()
-        self.append(filename)
+        self.append(filename, overwrite=False)
 
     def readString(self, sbol_str):
         """Read an RDF/XML string and attach the SBOL objects to
@@ -433,7 +433,7 @@ class Document(Identified):
         :return: None
         """
         self.clear()
-        self.appendString(sbol_str)
+        self.appendString(sbol_str, overwrite=False)
 
     def writeString(self):
         """
@@ -447,7 +447,7 @@ class Document(Identified):
         rdf = SBOL2Serialize.serialize_sboll2(self.graph).decode('utf-8')
         return rdf
 
-    def append(self, filename, overwrite: bool = True):
+    def append(self, filename, overwrite: bool = False):
         """
         Read an RDF/XML file and attach the SBOL objects to this Document.
 
@@ -461,17 +461,7 @@ class Document(Identified):
         new_graph.parse(filename, format='application/rdf+xml')
         self._append_graph(new_graph, overwrite)
 
-        # self.logger.debug("Appending data from file: " + filename)
-        # # Write our SBOL objects to an RDFlib graph
-        # self.update_graph()
-        # # Use rdflib to automatically merge the graphs together
-        # self.graph.parse(filename, format="application/rdf+xml")
-        # # Clear out the SBOL objects, but not the newly merged graph
-        # self.clear(clear_graph=False)
-        # # Base our internal representation on the new graph.
-        # self.parse_all()
-
-    def appendString(self, sbol_str: str, overwrite=True):
+    def appendString(self, sbol_str: str, overwrite: bool = False):
         """
         Read an RDF/XML document from a string and attach the SBOL
         objects to this Document.
@@ -487,7 +477,7 @@ class Document(Identified):
         new_graph.parse(data=sbol_str, format='application/rdf+xml')
         self._append_graph(new_graph, overwrite)
 
-    def _append_graph(self, new_graph: rdflib.Graph, overwrite: bool = True):
+    def _append_graph(self, new_graph: rdflib.Graph, overwrite: bool):
         # Gather all the objects that will be overwritten, stopping
         # if the user says not to overwrite. If we clear as we go we lose
         # the ability to find objects within objects. So gather the list
@@ -1250,7 +1240,7 @@ def IGEM_STANDARD_ASSEMBLY(parts_list):
     if not (G0000_uri in doc.componentDefinitions and
             G0002_uri in doc.componentDefinitions and
             G0000_seq_uri in doc.sequences and G0002_seq_uri in doc.sequences):
-        doc.appendString(igem_assembly_scars)
+        doc.appendString(igem_assembly_scars, overwrite=True)
 
     G0000 = doc.componentDefinitions[G0000_uri]
     G0002 = doc.componentDefinitions[G0002_uri]

--- a/sbol2/partshop.py
+++ b/sbol2/partshop.py
@@ -157,7 +157,7 @@ class PartShop:
             elif not response:
                 raise SBOLError(SBOLErrorCode.SBOL_ERROR_BAD_HTTP_REQUEST, response)
             # Add content to document
-            doc.appendString(response.content)
+            doc.appendString(response.content, overwrite=True)
             doc.resource_namespaces.add(self.resource)
 
     def submit(self, doc, collection='', overwrite=0):

--- a/test/test_document.py
+++ b/test/test_document.py
@@ -715,6 +715,14 @@ class TestDocumentExtensionObjects(unittest.TestCase):
         result = doc.appendString(doc.writeString(), overwrite=False)
         self.assertFalse(result)
 
+    def test_append_string(self):
+        doc = sbol2.Document()
+        cd = doc.componentDefinitions.create('cd1')
+        cd.components.create('c1')
+        self.assertEqual(1, len(cd.components))
+        doc.appendString(doc.writeString())
+        self.assertEqual(1, len(cd.components))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_document.py
+++ b/test/test_document.py
@@ -712,8 +712,11 @@ class TestDocumentExtensionObjects(unittest.TestCase):
 
     def test_append_string_no_overwrite(self):
         doc = sbol2.Document(CRISPR_LOCATION)
-        result = doc.appendString(doc.writeString(), overwrite=False)
-        self.assertFalse(result)
+        with self.assertRaises(sbol2.SBOLError) as cm:
+            doc.appendString(doc.writeString(), overwrite=False)
+        exc = cm.exception
+        self.assertEqual(sbol2.SBOLErrorCode.DUPLICATE_URI_ERROR,
+                         exc.error_code())
 
     def test_append_string(self):
         doc = sbol2.Document()

--- a/test/test_document.py
+++ b/test/test_document.py
@@ -710,6 +710,11 @@ class TestDocumentExtensionObjects(unittest.TestCase):
         sbol2.Config.setOption(sbol2.ConfigOptions.VALIDATE, validate)
         sbol2.Config.setOption(sbol2.ConfigOptions.VERBOSE, verbose)
 
+    def test_append_string_no_overwrite(self):
+        doc = sbol2.Document(CRISPR_LOCATION)
+        result = doc.appendString(doc.writeString(), overwrite=False)
+        self.assertFalse(result)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_document.py
+++ b/test/test_document.py
@@ -637,7 +637,7 @@ class TestDocumentExtensionObjects(unittest.TestCase):
         doc = sbol2.Document()
         self.assertIsNotNone(doc.version)
         old_version = doc.version
-        doc.append(CRISPR_LOCATION)
+        doc.append(CRISPR_LOCATION, overwrite=True)
         self.assertIsNotNone(doc.version)
         self.assertEqual(old_version, doc.version)
 
@@ -652,7 +652,7 @@ class TestDocumentExtensionObjects(unittest.TestCase):
         # Now load the same file again and make sure the size of the
         # document didn't increase, and the number of roles on the
         # ComponentDefinition didn't increase.
-        doc.append(CRISPR_LOCATION)
+        doc.append(CRISPR_LOCATION, overwrite=True)
         self.assertEqual(old_len, len(doc))
         cd = doc.componentDefinitions[cd_uri]
         self.assertEqual(1, len(cd.roles))
@@ -660,7 +660,7 @@ class TestDocumentExtensionObjects(unittest.TestCase):
         # Now load the file one more time and make sure the size of the
         # document didn't increase, and the number of roles on the
         # ComponentDefinition didn't increase.
-        doc.append(CRISPR_LOCATION)
+        doc.append(CRISPR_LOCATION, overwrite=True)
         self.assertEqual(old_len, len(doc))
         cd = doc.componentDefinitions[cd_uri]
         self.assertEqual(1, len(cd.roles))
@@ -676,7 +676,7 @@ class TestDocumentExtensionObjects(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdirname:
             temp_file = os.path.join(tmpdirname, 'test.xml')
             doc.write(temp_file)
-            doc.append(temp_file)
+            doc.append(temp_file, overwrite=True)
         cd = doc.componentDefinitions[cd_uri]
         self.assertEqual(old_component_len, len(cd.components))
         self.assertEqual(old_doc_len, len(doc))
@@ -723,7 +723,7 @@ class TestDocumentExtensionObjects(unittest.TestCase):
         cd = doc.componentDefinitions.create('cd1')
         cd.components.create('c1')
         self.assertEqual(1, len(cd.components))
-        doc.appendString(doc.writeString())
+        doc.appendString(doc.writeString(), overwrite=True)
         self.assertEqual(1, len(cd.components))
 
     def test_append_string_2(self):
@@ -737,7 +737,7 @@ class TestDocumentExtensionObjects(unittest.TestCase):
         cd_updated = doc2.componentDefinitions.create('cd1')
         cd_updated.components.create('c2')
         cd_updated.roles = ['bar']
-        doc.appendString(doc2.writeString())
+        doc.appendString(doc2.writeString(), overwrite=True)
         self.assertEqual(1, len(cd.components))
         self.assertEqual('c2', cd.components[0].displayId)
         self.assertEqual(cd.roles, ['bar'])

--- a/test/test_document.py
+++ b/test/test_document.py
@@ -723,6 +723,22 @@ class TestDocumentExtensionObjects(unittest.TestCase):
         doc.appendString(doc.writeString())
         self.assertEqual(1, len(cd.components))
 
+    def test_append_string_2(self):
+        doc = sbol2.Document()
+        cd = doc.componentDefinitions.create('cd1')
+        cd.components.create('c1')
+        cd.roles = ['foo']
+        self.assertEqual(1, len(cd.components))
+        self.assertEqual('c1', cd.components[0].displayId)
+        doc2 = sbol2.Document()
+        cd_updated = doc2.componentDefinitions.create('cd1')
+        cd_updated.components.create('c2')
+        cd_updated.roles = ['bar']
+        doc.appendString(doc2.writeString())
+        self.assertEqual(1, len(cd.components))
+        self.assertEqual('c2', cd.components[0].displayId)
+        self.assertEqual(cd.roles, ['bar'])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Adopt a bit of SynBioHub by giving the user control over whether append overwrites objects or aborts the merge. Funnel both Document.append() and Document.appendString() through common code to prep the document objects for
overwrite, and then loading the new information, overwriting those objects.

Fixes #359 