### PR TITLE
Retain referenced objects on copy

### DIFF
--- a/sbol2/identified.py
+++ b/sbol2/identified.py
@@ -226,6 +226,9 @@ class Identified(SBOLObject):
 
                             referenced_object = self.doc.find(uri)
                             if referenced_object is None:
+                                # This is a reference outside the document
+                                # so retain the reference.
+                                new_values.append(uri)
                                 continue
                             new_uri = replace_namespace(uri, target_namespace,
                                                         referenced_object.getTypeURI())

--- a/test/test_identified.py
+++ b/test/test_identified.py
@@ -326,6 +326,20 @@ class TestCopy(unittest.TestCase):
         # Confirm version is the same as the copied object
         self.assertEqual(comp3.version, '2')
 
+    def test_copy_issue_397(self):
+        sbol2.Config.setOption('sbol_typed_uris', False)
+        sbol2.Config.setOption('validate', False)
+        sbol2.setHomespace('http://synbict.org')
+        test_doc = sbol2.Document()
+        parent_comp = test_doc.componentDefinitions.create('parent')
+        child_sub_comp = parent_comp.components.create('child')
+        child_sub_comp.definition = 'http://synbict.org/child/1'
+        sbol2.setHomespace('http://sd2e.org')
+        parent_copy = parent_comp.copy(test_doc, 'http://synbict.org', '1')
+        child_copy = parent_copy.components.get('http://sd2e.org/parent/child/1')
+        self.assertIsNotNone(child_copy.definition)
+        self.assertEqual('http://synbict.org/child/1', child_copy.definition)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_partshop.py
+++ b/test/test_partshop.py
@@ -273,9 +273,8 @@ WHERE {{
         results = sbh.search("NAND")
         # The response is a list
         self.assertEqual(list, type(results))
-        # There are 25 items in the list (search returns more,
-        # but by default we get the first 25)
-        self.assertEqual(25, len(results))
+        # There are 18 items in the list as of 2021-Apr-14
+        self.assertEqual(18, len(results))
         # The response items are all of type Identified
         self.assertTrue(all([isinstance(x, sbol2.Identified)
                              for x in results]))
@@ -313,7 +312,7 @@ WHERE {{
                              for x in results]))
         doc = sbol2.Document()
         igem.pull([x.identity for x in results], doc, False)
-        self.assertEqual(5, len(doc))
+        self.assertEqual(10, len(doc))
         for cd in doc.componentDefinitions:
             self.assertIn(sbol2.SO_PROMOTER, cd.roles)
 


### PR DESCRIPTION
When copying objects, if a referenced object is not in the document, retain the reference instead of dropping it.

Fixes #397 