### PR TITLE
Prevent failing build jobs from canceling other jobs

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -13,6 +13,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+#      When set to true, GitHub cancels all in-progress jobs if any matrix job fails. Default: true
+      fail-fast: false
       matrix:
         # Default builds are on Ubuntu
         os: [ubuntu-latest]


### PR DESCRIPTION
Use strategy.fail-fast = false to avoid having one failing jobs
terminate the other jobs. We'd like to know if some would pass, rather
than seeing everything as failed.