### PR TITLE
Solving override issue

### DIFF
--- a/sbol2/sequence.py
+++ b/sbol2/sequence.py
@@ -128,7 +128,7 @@ class Sequence(TopLevel):
                 cdef = self.doc.getComponentDefinition(c.definition)
                 if not cdef.sequence:
                     if Config.getOption(ConfigOptions.SBOL_COMPLIANT_URIS):
-                        seq = self.doc.sequences.create(cdef.displayId)
+                        seq = self.doc.sequences.create(cdef.displayId + '_seq')
                         # cdef.sequence = seq
                         cdef.sequences = seq.identity
                     else:


### PR DESCRIPTION
I think there was a mistake here. Either line 131 should add _seq or line 130 should check SBOL_TYPED_URIS. Otherwise you end up with a warning: An object with this identity is already contained in the Document'