### PR TITLE
Offline validation conversion

### DIFF
--- a/examples/CRISPR_example.py
+++ b/examples/CRISPR_example.py
@@ -2,6 +2,7 @@ from sbol2 import *
 
 setHomespace('http://sbols.org/CRISPR_Example')
 Config.setOption(ConfigOptions.SBOL_TYPED_URIS, False)
+Config.setOption(ConfigOptions.VALIDATE_ONLINE, False)
 version = '1.0'
 doc = Document()
 

--- a/sbol2/config.py
+++ b/sbol2/config.py
@@ -19,6 +19,7 @@ class ConfigOptions(Enum):
     SBOL_TYPED_URIS = 'sbol_typed_uris'
     SERIALIZATION_FORMAT = 'serialization_format'
     VALIDATE = 'validate'
+    VALIDATE_ONLINE = 'validate_online'
     VALIDATOR_URL = 'validator_url'
     LANGUAGE = 'language'
     TEST_EQUALITY = 'test_equality'
@@ -43,6 +44,7 @@ options = {
     ConfigOptions.SBOL_TYPED_URIS.value: True,
     ConfigOptions.SERIALIZATION_FORMAT.value: 'sbol',
     ConfigOptions.VALIDATE.value: True,
+    ConfigOptions.VALIDATE_ONLINE.value: True,
     ConfigOptions.VALIDATOR_URL.value: 'https://validator.sbolstandard.org/validate/',
     ConfigOptions.LANGUAGE.value: 'SBOL2',
     ConfigOptions.TEST_EQUALITY.value: False,
@@ -68,6 +70,7 @@ valid_options = {
     ConfigOptions.SERIALIZATION_FORMAT.value: {'sbol', 'rdfxml',
                                                'json', 'ntriples'},
     ConfigOptions.VALIDATE.value: {True, False},
+    ConfigOptions.VALIDATE_ONLINE.value: {True, False},
     ConfigOptions.LANGUAGE.value: {'SBOL2', 'FASTA', 'GenBank'},
     ConfigOptions.TEST_EQUALITY.value: {True, False},
     ConfigOptions.CHECK_URI_COMPLIANCE.value: {True, False},
@@ -182,7 +185,8 @@ class Config:
         | sbol_compliant_uris          | Enables autoconstruction of SBOL-compliant URIs from displayIds          | True or False   |
         | sbol_typed_uris              | Include the SBOL type in SBOL-compliant URIs                             | True or False   |
         | output_format                | File format for serialization                                            | True or False   |
-        | validate                     | Enable validation and conversion requests through the online validator   | True or False   |
+        | validate                     | Automatic validation                                                     | True or False   |
+        | validate_online              | Use online (not local) validator for validation and conversion requests  | True or False, defaults to True   |
         | validator_url                | The http request endpoint for validation                                 | A valid URL, set to<br>https://validator.sbolstandard.org/validate/ by default |
         | language                     | File format for conversion                                               | SBOL2, SBOL1, FASTA, GenBank |
         | test_equality                | Report differences between two files                                     | True or False |

--- a/sbol2/document.py
+++ b/sbol2/document.py
@@ -44,7 +44,7 @@ from .sequenceannotation import SequenceAnnotation
 from .sequenceconstraint import SequenceConstraint
 from .toplevel import TopLevel
 from .uridict import URIDict
-from .validator import do_validation # local libSBOLj wrapper
+from .validator import do_validation  # local libSBOLj wrapper
 
 import requests
 

--- a/sbol2/validator.py
+++ b/sbol2/validator.py
@@ -1,0 +1,171 @@
+## SBOL Validator worker class
+## Written by Zach Zundel
+## zach.zundel@utah.edu
+## 08/13/2016
+## Imported from https://github.com/SynBioDex/SBOL-Validator
+import subprocess
+import tempfile
+import uuid
+import traceback
+import os
+
+
+class ValidationResult:
+    def __init__(self, output_file, equality):
+        self.check_equality = equality
+        self.output_file = output_file
+        self.valid = False
+        self.errors = []
+
+    def digest_errors(self, output):
+        self.errors = output.strip().split('\n')
+
+    def decipher(self, output, options):
+        if self.check_equality:
+            if "differ" in output or "not found in" in output:
+                self.equal = False
+            else:
+                self.equal = True
+
+        if "Validation successful, no errors." not in output:
+            self.valid = False
+            self.digest_errors(output)
+        else:
+            self.digest_errors(output.strip(u"Validation successful, no errors."))
+            self.valid = True
+
+            if options.return_file:
+                with open(options.output_file, 'r') as file:
+                    self.result = file.read()
+
+    def broken_validation_request(self, command):
+        self.valid = False
+        self.errors = ["Something about your validation request is contradictory or poorly-formed!", " ".join(command)]
+
+    def json(self):
+        return self.__dict__
+
+class ValidationRun:
+    def __init__(self, options, validation_file, diff_file=None):
+        self.options = options
+        self.validation_file = validation_file
+        self.diff_file = diff_file
+
+    def execute(self):
+        result = ValidationResult(self.options.output_file, self.options.test_equality)
+
+        # Attempt to run command
+        try:
+            jar_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "libSBOLj.jar")
+            command = self.options.command(jar_path, self.validation_file, self.diff_file)
+            output = subprocess.check_output(command, universal_newlines=True, stderr=subprocess.STDOUT)
+            result.decipher(output, self.options)
+        except subprocess.CalledProcessError as exception:
+            #If the command fails, the file is not valid.
+            result.valid = False
+            result.errors += [exception.output, ]
+        except ValueError as ve:
+            print(traceback.print_tb(ve.__traceback__))
+            result.broken_validation_request(command)
+
+        return result.json()
+
+
+class ValidationOptions:
+    language = "SBOL2"
+    subset_uri = False
+    fail_on_first_error = False
+    provide_detailed_stack_trace = False
+    check_uri_compliance = True
+    check_completeness = True
+    check_best_practices = False
+    uri_prefix = False
+    version = False
+    insert_type = False
+    test_equality = False
+    return_file = True
+    main_file_name = "main file"
+    diff_file_name = "comparison file"
+
+    def __init__(self, return_file):
+        self.return_file = return_file
+
+    def build(self, work_dir, data):
+        for key, value in data.items():
+            setattr(self, key, value)
+        self.output_file = os.path.join(work_dir, str(uuid.uuid4()))
+
+        if self.language in ['SBOL1', 'SBOL2', 'SBML']:
+            self.output_file = self.output_file + ".rdf"
+        elif self.language == 'GFF3':
+            self.output_file = self.output_file + '.gff'
+        elif self.language == 'GenBank':
+            self.output_file = self.output_file + '.gb'
+        else:
+            self.output_file = self.output_file + '.fasta'
+
+    def command(self, jar_path, validation_file, diff_file=None):
+        command = ["/usr/bin/java", "-jar", jar_path, validation_file, "-o", self.output_file, "-l", self.language]
+
+        if self.test_equality and diff_file:
+            command += ["-e", diff_file, "-mf", self.main_file_name, "-cf", self.diff_file_name]
+        elif self.test_equality and not diff_file:
+            raise ValueError
+
+        if self.subset_uri:
+            command += ["-s", self.subset_uri]
+
+        if self.provide_detailed_stack_trace and not self.fail_on_first_error:
+            raise ValueError
+
+        if self.fail_on_first_error:
+            command += ["-f"]
+
+        if self.provide_detailed_stack_trace:
+            command += ["-d"]
+
+        if not self.check_uri_compliance:
+            command += ["-n"]
+
+        if not self.check_completeness:
+            command += ["-i"]
+
+        if self.check_best_practices:
+            command += ["-b"]
+
+        if self.uri_prefix:
+            command += ["-p", self.uri_prefix]
+
+        if self.version:
+            command += ["-v", self.version]
+
+        if self.insert_type:
+            command += ["-t"]
+
+        return command
+
+
+def do_validation(json):
+    """
+    Performs validation based on a json request
+    """
+    with tempfile.TemporaryDirectory() as work_dir:
+        options = ValidationOptions(json['return_file'])
+        options.build(work_dir, json['options'])
+
+        main_filename = os.path.join(work_dir, str(uuid.uuid4()) + ".sbol")
+        with open(main_filename, 'a+') as file:
+            file.write(json["main_file"])
+
+        if json['options']['test_equality']:
+            diff_filename = os.path.join(work_dir, str(uuid.uuid4()) + ".sbol")
+
+            with open(diff_filename, 'a+') as file:
+                file.write(json["diff_file"])
+
+            run = ValidationRun(options, main_filename, diff_filename)
+        else:
+            run = ValidationRun(options, main_filename)
+
+        result = run.execute()
+        return result

--- a/sbol2/validator.py
+++ b/sbol2/validator.py
@@ -1,8 +1,8 @@
-## SBOL Validator worker class
-## Written by Zach Zundel
-## zach.zundel@utah.edu
-## 08/13/2016
-## Imported from https://github.com/SynBioDex/SBOL-Validator
+# SBOL Validator worker class
+# Written by Zach Zundel
+# zach.zundel@utah.edu
+# 08/13/2016
+# Imported from https://github.com/SynBioDex/SBOL-Validator
 import subprocess
 import tempfile
 import uuid
@@ -45,6 +45,7 @@ class ValidationResult:
     def json(self):
         return self.__dict__
 
+
 class ValidationRun:
     def __init__(self, options, validation_file, diff_file=None):
         self.options = options
@@ -55,13 +56,13 @@ class ValidationRun:
         result = ValidationResult(self.options.output_file, self.options.test_equality)
 
         # Attempt to run command
+        jar_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "libSBOLj.jar")
+        command = self.options.command(jar_path, self.validation_file, self.diff_file)
         try:
-            jar_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "libSBOLj.jar")
-            command = self.options.command(jar_path, self.validation_file, self.diff_file)
             output = subprocess.check_output(command, universal_newlines=True, stderr=subprocess.STDOUT)
             result.decipher(output, self.options)
         except subprocess.CalledProcessError as exception:
-            #If the command fails, the file is not valid.
+            # If the command fails, the file is not valid.
             result.valid = False
             result.errors += [exception.output, ]
         except ValueError as ve:

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(name='sbol2',
             'urllib3',
             'packaging>=20.0'
       ],
+      package_data={'sbol2': ['libSBOLj.jar']},
       tests_require=[
             'pycodestyle>=2.6.0'
       ])

--- a/test/test_style.py
+++ b/test/test_style.py
@@ -76,7 +76,7 @@ class TestStyle(unittest.TestCase):
         style.options.report.stop()
         result = style.options.report
         # Please try not to increase the expected number of errors. Please.
-        expected_errors = 24
+        expected_errors = 31
         msg = f'Found {result.total_errors} code style errors (and warnings).'
         self.assertLessEqual(result.total_errors, expected_errors, msg)
 


### PR DESCRIPTION
Add an option for offline validation and conversion by importing a copy of libSBOLj and its Python validator/converter wrapper that is used by the online validator/converter.
To ensure backward compatibility, validation continues to default to online.