### PR TITLE
Change JAVA path to update pysbol2 conda package

### DIFF
--- a/sbol2/config.py
+++ b/sbol2/config.py
@@ -47,7 +47,7 @@ options = {
     ConfigOptions.VALIDATE.value: True,
     ConfigOptions.VALIDATE_ONLINE.value: True,
     ConfigOptions.VALIDATOR_URL.value: 'https://validator.sbolstandard.org/validate/',
-    ConfigOptions.JAVA_LOCATION.value: '/usr/bin/java',
+    ConfigOptions.JAVA_LOCATION.value: 'java',
     ConfigOptions.LANGUAGE.value: 'SBOL2',
     ConfigOptions.TEST_EQUALITY.value: False,
     ConfigOptions.CHECK_URI_COMPLIANCE.value: False,


### PR DESCRIPTION
Hi @tcmitchell  @jakebeal ,

This is a pull request where I changed the JAVA path from` /usr/bin/java `to `java` (discussed here: https://github.com/SynBioDex/pySBOL2/issues/417) in `sbol2/config.py` file. So, I'm trying to update the pysbol2 conda package and this JAVA path `/usr/bin/java` is not found by conda even If I added openjdk to conda dependencies, But it's working when I specify only` java`.

Can you check if this is working in your environment this way and if it's the case, can you add a new tag including these modifications ?

Thank you.

Best wishes,

Kenza BAZI KABBAJ