### PR TITLE
Increase python version coverage

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -19,7 +19,7 @@ jobs:
         # Default builds are on Ubuntu
         os: [ubuntu-latest]
 #        python-version: [3.7, 3.8, 3.9, pypy-3.7]
-        python-version: [3.7, 3.8, 3.9, 3.10, pypy-3.9]
+        python-version: ['3.7', '3.8', '3.9', '3.10', 'pypy-3.9']
         include:
           # Also test on macOS and Windows using latest Python 3
           - os: macos-latest

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -19,7 +19,7 @@ jobs:
         # Default builds are on Ubuntu
         os: [ubuntu-latest]
 #        python-version: [3.7, 3.8, 3.9, pypy-3.7]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, 3.10, pypy-3.9]
         include:
           # Also test on macOS and Windows using latest Python 3
           - os: macos-latest


### PR DESCRIPTION
Add python 3.10 and pypy 3.9 to CI builds.