### PR TITLE
Use `Graph.parse` instead of `Graph.load`

### DIFF
--- a/test/test_crispr.py
+++ b/test/test_crispr.py
@@ -36,11 +36,11 @@ class TestCrisprExample(unittest.TestCase):
         self.assertTrue(os.path.exists(out_path))
         # Load the output
         actual_graph = rdflib.Graph()
-        actual_graph.load(out_path)
+        actual_graph.parse(out_path)
         actual_iso = rdflib.compare.to_isomorphic(actual_graph)
         # Load the expected output
         expected_graph = rdflib.Graph()
-        expected_graph.load(EXPECTED_SBOL)
+        expected_graph.parse(EXPECTED_SBOL)
         expected_iso = rdflib.compare.to_isomorphic(expected_graph)
         rdf_diff = rdflib.compare.graph_diff(expected_iso, actual_iso)
         if rdf_diff[1] or rdf_diff[2]:

--- a/test/test_roundtrip.py
+++ b/test/test_roundtrip.py
@@ -52,10 +52,10 @@ class TestRoundTripSBOL2(unittest.TestCase):
 
         # Now compare the graphs in RDF
         g1 = rdflib.Graph()
-        g1.load(test_path)
+        g1.parse(test_path)
         iso1 = rdflib.compare.to_isomorphic(g1)
         g2 = rdflib.Graph()
-        g2.load(test2_path)
+        g2.parse(test2_path)
         iso2 = rdflib.compare.to_isomorphic(g2)
         rdf_diff = rdflib.compare.graph_diff(iso1, iso2)
         if rdf_diff[1] or rdf_diff[2]:


### PR DESCRIPTION
RDFlib 6.2 removed `Graph.load`, which was deprecated and scheduled for
removal in RDFlib 6.0. Update unit tests that were still using `Graph.load`.