### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -19,7 +19,6 @@ jobs:
       matrix:
         # Default builds are on Ubuntu
         os: [ubuntu-22.04]
-#        python-version: [3.7, 3.8, 3.9, pypy-3.7]
         python-version: ['3.7', '3.8', '3.9', '3.10', 'pypy-3.9']
         include:
           # Also test on macOS and Windows using latest Python 3

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         # Default builds are on Ubuntu
-        os: [ubuntu-latest]
+        os: [ubuntu-22.04]
 #        python-version: [3.7, 3.8, 3.9, pypy-3.7]
         python-version: ['3.7', '3.8', '3.9', '3.10', 'pypy-3.9']
         include:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -18,8 +18,8 @@ jobs:
       fail-fast: false
       matrix:
         # Default builds are on Ubuntu
-        os: [ubuntu-22.04]
-        python-version: ['3.7', '3.8', '3.9', '3.10', 'pypy-3.9']
+        os: [ubuntu-latest]
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', 'pypy-3.10']
         include:
           # Also test on macOS and Windows using latest Python 3
           - os: macos-latest

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # pySBOL2
-[![Build Status](https://travis-ci.org/SynBioDex/pySBOL2.svg?branch=master)](https://travis-ci.org/SynBioDex/pySBOL2)
+![gh-action badge](https://github.com/SynBioDex/pySBOL2/workflows/Python%20package/badge.svg)
 [![Documentation Status](https://readthedocs.org/projects/pysbol/badge/?version=latest)](https://pysbol.readthedocs.io/en/latest/?badge=latest)
 
 **pySBOL2** is a pure Python implementation of the

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pySBOL2
 ![gh-action badge](https://github.com/SynBioDex/pySBOL2/workflows/Python%20package/badge.svg)
-[![Documentation Status](https://readthedocs.org/projects/pysbol/badge/?version=latest)](https://pysbol.readthedocs.io/en/latest/?badge=latest)
+![readthedocs badge](https://readthedocs.org/projects/pysbol2/badge/)
 
 **pySBOL2** is a pure Python implementation of the
 SBOL 2.3.0 standard [Synthetic Biology Open Language (SBOL)](https://sbolstandard.org/) - 


### PR DESCRIPTION
Fixes CI badges in README and fixes CI build.

Python 3.7 is no longer included in Ubuntu versions > 22.04 (See https://github.com/actions/setup-python/issues/962).  Since our CI matrix was set to use more recent Ubuntu versionw and Python 3.7 was missing, CI was subsequently failing.  We subsequently decided to deprecate 3.7 and 3.8 and test for currently supported Python versions 3.9-3.13.

