### PR TITLE
Fix failing builds

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -19,14 +19,13 @@ jobs:
       matrix:
         # Default builds are on Ubuntu
         os: [ubuntu-latest]
-#        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', 'pypy-3.10']
-        python-version: ['3.14']
-#        include:
-#          # Also test on macOS and Windows using latest Python 3
-#          - os: macos-latest
-#            python-version: 3.x
-#          - os: windows-latest
-#            python-version: 3.x
+        python-version: ['3.11', '3.12', '3.13', '3.14', 'pypy-3.11']
+        include:
+          # Also test on macOS and Windows using latest Python 3
+          - os: macos-latest
+            python-version: 3.x
+          - os: windows-latest
+            python-version: 3.x
     steps:
     - uses: actions/checkout@v7
       # https://github.com/actions/checkout

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -19,13 +19,14 @@ jobs:
       matrix:
         # Default builds are on Ubuntu
         os: [ubuntu-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', 'pypy-3.10']
-        include:
-          # Also test on macOS and Windows using latest Python 3
-          - os: macos-latest
-            python-version: 3.x
-          - os: windows-latest
-            python-version: 3.x
+#        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', 'pypy-3.10']
+        python-version: ['3.14']
+#        include:
+#          # Also test on macOS and Windows using latest Python 3
+#          - os: macos-latest
+#            python-version: 3.x
+#          - os: windows-latest
+#            python-version: 3.x
     steps:
     - uses: actions/checkout@v7
       # https://github.com/actions/checkout

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -27,11 +27,13 @@ jobs:
           - os: windows-latest
             python-version: 3.x
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v7
+      # https://github.com/actions/checkout
       with:
         submodules: 'recursive'
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      # https://github.com/actions/setup-python
+      uses: actions/setup-python@v7
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed
+
+- Constrain `packaging` version to `<26.1` to keep using `NegativeInfinity`.
+  [449](https://github.com/SynBioDex/pySBOL2/issues/449)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,5 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Temporarily skip SynBioHub unit tests to fix failing builds.
+  [449](https://github.com/SynBioDex/pySBOL2/issues/449),
+  [451](https://github.com/SynBioDex/pySBOL2/issues/451)
 - Constrain `packaging` version to `<26.1` to keep using `NegativeInfinity`.
-  [449](https://github.com/SynBioDex/pySBOL2/issues/449)
+  [449](https://github.com/SynBioDex/pySBOL2/issues/449),
+  [450](https://github.com/SynBioDex/pySBOL2/issues/450)
+
+## [1.4.1] - 2022-04-14
+
+- Changes were not recorded.
+
+## [1.4.1] - 2022-02-04
+
+- Changes were not recorded.

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,9 @@ setup(name='sbol2',
             'lxml',
             'requests',
             'urllib3',
-            'packaging>=20.0'
+            # As of August 2026 the code is incompatible with packaging >= 26.1
+            # https://github.com/SynBioDex/pySBOL2/issues/450
+            'packaging<26.1'
       ],
       package_data={'sbol2': ['libSBOLj.jar']},
       tests_require=[

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 setup(name='sbol2',
       version='1.5',
       description='Pure Python implementation of SBOL 2 standard',
-      python_requires='>=3.7',
+      python_requires='>=3.11',
       url='https://github.com/SynBioDex/pySBOL2',
       author='Bryan Bartley',
       author_email='editors@sbolstandard.org',

--- a/test/test_partshop.py
+++ b/test/test_partshop.py
@@ -63,13 +63,14 @@ class TestPartShop(unittest.TestCase):
         #     print(obj)
         self.assertEqual(1, len(doc))
 
+    @unittest.skip("SynBioHub no longer allows this kind of anonymous access")
     def test_login(self):
         # NOTE: Add /login because login pages may be different
         # depending on what site you're accessing
         igem = sbol.PartShop(TEST_RESOURCE_MAIN)
         response = igem.login('johndoe@example.org', 'test')
         # As of August 2026 we get Forbidden as a response.
-        self.assertIn(response.status_code, [HTTPStatus.OK, HTTPStatus.FORBIDDEN])
+        self.assertEqual(response.status_code, 200)
 
     def test_login_bad(self):
         igem = sbol.PartShop(TEST_RESOURCE_MAIN)

--- a/test/test_partshop.py
+++ b/test/test_partshop.py
@@ -23,6 +23,8 @@ else:
 
 
 class TestPartShop(unittest.TestCase):
+
+    @unittest.skipIf(password is None, "No SynBioHub password supplied")
     def test_pull_00(self):
         # Based on tutorial: https://pysbol2.readthedocs.io/en/latest/repositories.html
         doc = sbol.Document()
@@ -33,6 +35,7 @@ class TestPartShop(unittest.TestCase):
         #     print(obj)
         self.assertEqual(3, len(doc))
 
+    @unittest.skipIf(password is None, "No SynBioHub password supplied")
     def test_pull_01(self):
         # Based on tutorial: https://pysbol2.readthedocs.io/en/latest/repositories.html
         doc = sbol.Document()
@@ -45,6 +48,7 @@ class TestPartShop(unittest.TestCase):
         #     print(obj)
         self.assertEqual(7, len(doc))
 
+    @unittest.skipIf(password is None, "No SynBioHub password supplied")
     def test_pull_02(self):
         # I don't know what this adds over test_pull_01
         # This is a replacement for a previous test whose part was no
@@ -73,7 +77,7 @@ class TestPartShop(unittest.TestCase):
             self.assertEqual(sbol_error.error_code(),
                              sbol.SBOLErrorCode.SBOL_ERROR_BAD_HTTP_REQUEST)
 
-    @unittest.skipIf(password is None, "No password supplied")
+    @unittest.skipIf(password is None, "No SynBioHub password supplied")
     def test_submit_00(self):
         RESOURCE = 'https://synbiohub.utah.edu'
         doc = sbol.Document()
@@ -148,7 +152,7 @@ WHERE {
         part_shop.spoof(spoofed_url)
         self.assertEqual(part_shop.getSpoofedURL(), spoofed_url)
 
-    @unittest.skipIf(password is None, "No password supplied")
+    @unittest.skipIf(password is None, "No SynBioHub password supplied")
     def test_submit(self):
         # This test is derived from an etl-to-synbiohub_pipeline test
         # case that was failing.
@@ -217,7 +221,7 @@ WHERE {
         else:
             self.fail('Expected SBOLError')
 
-    @unittest.skipIf(password is None, "No password supplied")
+    @unittest.skipIf(password is None, "No SynBioHub password supplied")
     def test_attach_file(self):
         sbol2.Config.setOption('sbol_typed_uris', False)
         doc = sbol2.Document()
@@ -267,6 +271,7 @@ WHERE {{
         e = cm.exception
         self.assertEqual(e.error_code(), sbol2.SBOLErrorCode.SBOL_ERROR_NOT_FOUND)
 
+    @unittest.skipIf(password is None, "No SynBioHub password supplied")
     def test_search_general(self):
         sbh = sbol2.PartShop(TEST_RESOURCE_MAIN)
         # sbh.login(username, password)
@@ -277,6 +282,7 @@ WHERE {{
         self.assertTrue(all([isinstance(x, sbol2.Identified)
                              for x in results]))
 
+    @unittest.skipIf(password is None, "No SynBioHub password supplied")
     def test_search_general_offset_limit(self):
         # Test a general search using offset and limit
         # This comes from a documentation example that was failing
@@ -294,6 +300,7 @@ WHERE {{
         self.assertTrue(all([isinstance(x, sbol2.Identified)
                              for x in results]))
 
+    @unittest.skipIf(password is None, "No SynBioHub password supplied")
     def test_search_exact(self):
         igem = sbol.PartShop(TEST_RESOURCE_MAIN)
         limit = 10
@@ -314,6 +321,7 @@ WHERE {{
         for cd in doc.componentDefinitions:
             self.assertIn(sbol2.SO_PROMOTER, cd.roles)
 
+    @unittest.skipIf(password is None, "No SynBioHub password supplied")
     def test_pull_doc_version(self):
         # After a pull the document version was erroneously set to None (#281)
         doc = sbol.Document()
@@ -325,6 +333,7 @@ WHERE {{
         self.assertIsNotNone(doc.version)
         self.assertEqual(old_version, doc.version)
 
+    @unittest.skipIf(password is None, "No SynBioHub password supplied")
     def test_search_count(self):
         part_shop = sbol2.PartShop('https://synbiohub.org/public/igem')
         # searchCount did not exist, see #322

--- a/test/test_partshop.py
+++ b/test/test_partshop.py
@@ -1,6 +1,8 @@
 import os
 import unittest
 import json
+from http import HTTPStatus
+
 import requests
 
 import sbol2 as sbol
@@ -66,7 +68,8 @@ class TestPartShop(unittest.TestCase):
         # depending on what site you're accessing
         igem = sbol.PartShop(TEST_RESOURCE_MAIN)
         response = igem.login('johndoe@example.org', 'test')
-        self.assertEqual(response.status_code, 200)
+        # As of August 2026 we get Forbidden as a response.
+        self.assertIn(response.status_code, [HTTPStatus.OK, HTTPStatus.FORBIDDEN])
 
     def test_login_bad(self):
         igem = sbol.PartShop(TEST_RESOURCE_MAIN)
@@ -90,6 +93,7 @@ class TestPartShop(unittest.TestCase):
         response = ps.submit(doc, overwrite=1)
         self.assertEqual(response.status_code, 200)
 
+    @unittest.skip("SynBioHub no longer allows this kind of anonymous access")
     def test_sparqlQuery_00(self):
         ps = sbol.PartShop(TEST_RESOURCE_MAIN)
         response = ps.login('johndoe', 'test')

--- a/test/test_partshop.py
+++ b/test/test_partshop.py
@@ -1,7 +1,6 @@
 import os
 import unittest
 import json
-from http import HTTPStatus
 
 import requests
 
@@ -26,6 +25,7 @@ else:
 
 class TestPartShop(unittest.TestCase):
 
+    # https://github.com/SynBioDex/pySBOL2/issues/451
     @unittest.skipIf(password is None, "No SynBioHub password supplied")
     def test_pull_00(self):
         # Based on tutorial: https://pysbol2.readthedocs.io/en/latest/repositories.html
@@ -37,6 +37,7 @@ class TestPartShop(unittest.TestCase):
         #     print(obj)
         self.assertEqual(3, len(doc))
 
+    # https://github.com/SynBioDex/pySBOL2/issues/451
     @unittest.skipIf(password is None, "No SynBioHub password supplied")
     def test_pull_01(self):
         # Based on tutorial: https://pysbol2.readthedocs.io/en/latest/repositories.html
@@ -50,6 +51,7 @@ class TestPartShop(unittest.TestCase):
         #     print(obj)
         self.assertEqual(7, len(doc))
 
+    # https://github.com/SynBioDex/pySBOL2/issues/451
     @unittest.skipIf(password is None, "No SynBioHub password supplied")
     def test_pull_02(self):
         # I don't know what this adds over test_pull_01
@@ -63,13 +65,13 @@ class TestPartShop(unittest.TestCase):
         #     print(obj)
         self.assertEqual(1, len(doc))
 
+    # https://github.com/SynBioDex/pySBOL2/issues/451
     @unittest.skip("SynBioHub no longer allows this kind of anonymous access")
     def test_login(self):
         # NOTE: Add /login because login pages may be different
         # depending on what site you're accessing
         igem = sbol.PartShop(TEST_RESOURCE_MAIN)
         response = igem.login('johndoe@example.org', 'test')
-        # As of August 2026 we get Forbidden as a response.
         self.assertEqual(response.status_code, 200)
 
     def test_login_bad(self):
@@ -94,6 +96,7 @@ class TestPartShop(unittest.TestCase):
         response = ps.submit(doc, overwrite=1)
         self.assertEqual(response.status_code, 200)
 
+    # https://github.com/SynBioDex/pySBOL2/issues/451
     @unittest.skip("SynBioHub no longer allows this kind of anonymous access")
     def test_sparqlQuery_00(self):
         ps = sbol.PartShop(TEST_RESOURCE_MAIN)
@@ -276,6 +279,7 @@ WHERE {{
         e = cm.exception
         self.assertEqual(e.error_code(), sbol2.SBOLErrorCode.SBOL_ERROR_NOT_FOUND)
 
+    # https://github.com/SynBioDex/pySBOL2/issues/451
     @unittest.skipIf(password is None, "No SynBioHub password supplied")
     def test_search_general(self):
         sbh = sbol2.PartShop(TEST_RESOURCE_MAIN)
@@ -287,6 +291,7 @@ WHERE {{
         self.assertTrue(all([isinstance(x, sbol2.Identified)
                              for x in results]))
 
+    # https://github.com/SynBioDex/pySBOL2/issues/451
     @unittest.skipIf(password is None, "No SynBioHub password supplied")
     def test_search_general_offset_limit(self):
         # Test a general search using offset and limit
@@ -305,6 +310,7 @@ WHERE {{
         self.assertTrue(all([isinstance(x, sbol2.Identified)
                              for x in results]))
 
+    # https://github.com/SynBioDex/pySBOL2/issues/451
     @unittest.skipIf(password is None, "No SynBioHub password supplied")
     def test_search_exact(self):
         igem = sbol.PartShop(TEST_RESOURCE_MAIN)
@@ -326,6 +332,7 @@ WHERE {{
         for cd in doc.componentDefinitions:
             self.assertIn(sbol2.SO_PROMOTER, cd.roles)
 
+    # https://github.com/SynBioDex/pySBOL2/issues/451
     @unittest.skipIf(password is None, "No SynBioHub password supplied")
     def test_pull_doc_version(self):
         # After a pull the document version was erroneously set to None (#281)
@@ -338,6 +345,7 @@ WHERE {{
         self.assertIsNotNone(doc.version)
         self.assertEqual(old_version, doc.version)
 
+    # https://github.com/SynBioDex/pySBOL2/issues/451
     @unittest.skipIf(password is None, "No SynBioHub password supplied")
     def test_search_count(self):
         part_shop = sbol2.PartShop('https://synbiohub.org/public/igem')

--- a/test/test_searchquery.py
+++ b/test/test_searchquery.py
@@ -1,9 +1,19 @@
+import os
 import unittest
 
 import sbol2
 
 
 GSOC_SBH_URL = 'https://synbiohub.org'
+
+if 'SBH_USER' in os.environ:
+    username = os.environ['SBH_USER']
+else:
+    username = None
+if 'SBH_PASSWORD' in os.environ:
+    password = os.environ['SBH_PASSWORD']
+else:
+    password = None
 
 
 class TestSearchQuery(unittest.TestCase):
@@ -14,6 +24,7 @@ class TestSearchQuery(unittest.TestCase):
         self.assertIn(sbol2.SBOL_TYPES, query.properties)
         self.assertEqual(sbol2.BIOPAX_DNA, query[sbol2.SBOL_TYPES])
 
+    @unittest.skipIf(password is None, "No SynBioHub password supplied")
     def test_gsoc_example_1_title(self):
         # See issue #240
         collection = 'https://synbiohub.org/public/igem/igem_collection/1'
@@ -34,6 +45,7 @@ class TestSearchQuery(unittest.TestCase):
         names = [r.name == title for r in response]
         self.assertTrue(all(names))
 
+    @unittest.skipIf(password is None, "No SynBioHub password supplied")
     def test_gsoc_example_1_display_id(self):
         # See issue #240
         collection = 'https://synbiohub.org/public/igem/igem_collection/1'
@@ -76,6 +88,7 @@ class TestSearchQuery(unittest.TestCase):
         results.extend(self.gsoc_search_display_id(part_shop, collection, term))
         return results
 
+    @unittest.skipIf(password is None, "No SynBioHub password supplied")
     def test_gsoc_example_2(self):
         # Looking for: https://synbiohub.org/public/igem/BBa_R0010/1
         #              and/or https://synbiohub.org/public/igem/BBa_C0012/1
@@ -93,6 +106,7 @@ class TestSearchQuery(unittest.TestCase):
         self.assertNotIn('https://synbiohub.org/public/igem/BBa_S03334/1', identities)
         self.assertNotIn('https://synbiohub.org/public/igem/BBa_K1444015/1', identities)
 
+    @unittest.skipIf(password is None, "No SynBioHub password supplied")
     def test_gsoc_example_3(self):
         # Looking for: https://synbiohub.org/public/igem/BBa_R0010/1
         # Collection: https://synbiohub.org/public/igem/igem_collection/1
@@ -107,6 +121,7 @@ class TestSearchQuery(unittest.TestCase):
         self.assertNotIn('https://synbiohub.org/public/igem/BBa_S03334/1', identities)
         self.assertNotIn('https://synbiohub.org/public/igem/BBa_K1444015/1', identities)
 
+    @unittest.skipIf(password is None, "No SynBioHub password supplied")
     def test_gsoc_example_4(self):
         # Looking for: https://synbiohub.org/public/igem/BBa_B0034/1
         # Collection: https://synbiohub.org/public/igem/igem_collection/1
@@ -119,6 +134,7 @@ class TestSearchQuery(unittest.TestCase):
         self.assertIn('https://synbiohub.org/public/igem/BBa_B0034/1', identities)
         self.assertNotIn('https://synbiohub.org/public/igem/BBa_I13617/1', identities)
 
+    @unittest.skipIf(password is None, "No SynBioHub password supplied")
     def test_gsoc_example_5(self):
         # Looking for: https://synbiohub.org/public/bsu/BO_28874/1
         # Collection: https://synbiohub.org/public/bsu/bsu_collection/1
@@ -132,6 +148,7 @@ class TestSearchQuery(unittest.TestCase):
         self.assertIn('https://synbiohub.org/public/bsu/BO_28874/1', identities)
         self.assertNotIn('https://synbiohub.org/public/bsu/BO_26604/1', identities)
 
+    @unittest.skipIf(password is None, "No SynBioHub password supplied")
     def test_gsoc_count_5(self):
         part_shop = sbol2.PartShop(GSOC_SBH_URL)
         query = sbol2.SearchQuery()

--- a/test/test_searchquery.py
+++ b/test/test_searchquery.py
@@ -24,6 +24,7 @@ class TestSearchQuery(unittest.TestCase):
         self.assertIn(sbol2.SBOL_TYPES, query.properties)
         self.assertEqual(sbol2.BIOPAX_DNA, query[sbol2.SBOL_TYPES])
 
+    # https://github.com/SynBioDex/pySBOL2/issues/451
     @unittest.skipIf(password is None, "No SynBioHub password supplied")
     def test_gsoc_example_1_title(self):
         # See issue #240
@@ -45,6 +46,7 @@ class TestSearchQuery(unittest.TestCase):
         names = [r.name == title for r in response]
         self.assertTrue(all(names))
 
+    # https://github.com/SynBioDex/pySBOL2/issues/451
     @unittest.skipIf(password is None, "No SynBioHub password supplied")
     def test_gsoc_example_1_display_id(self):
         # See issue #240
@@ -88,6 +90,7 @@ class TestSearchQuery(unittest.TestCase):
         results.extend(self.gsoc_search_display_id(part_shop, collection, term))
         return results
 
+    # https://github.com/SynBioDex/pySBOL2/issues/451
     @unittest.skipIf(password is None, "No SynBioHub password supplied")
     def test_gsoc_example_2(self):
         # Looking for: https://synbiohub.org/public/igem/BBa_R0010/1
@@ -106,6 +109,7 @@ class TestSearchQuery(unittest.TestCase):
         self.assertNotIn('https://synbiohub.org/public/igem/BBa_S03334/1', identities)
         self.assertNotIn('https://synbiohub.org/public/igem/BBa_K1444015/1', identities)
 
+    # https://github.com/SynBioDex/pySBOL2/issues/451
     @unittest.skipIf(password is None, "No SynBioHub password supplied")
     def test_gsoc_example_3(self):
         # Looking for: https://synbiohub.org/public/igem/BBa_R0010/1
@@ -121,6 +125,7 @@ class TestSearchQuery(unittest.TestCase):
         self.assertNotIn('https://synbiohub.org/public/igem/BBa_S03334/1', identities)
         self.assertNotIn('https://synbiohub.org/public/igem/BBa_K1444015/1', identities)
 
+    # https://github.com/SynBioDex/pySBOL2/issues/451
     @unittest.skipIf(password is None, "No SynBioHub password supplied")
     def test_gsoc_example_4(self):
         # Looking for: https://synbiohub.org/public/igem/BBa_B0034/1
@@ -134,6 +139,7 @@ class TestSearchQuery(unittest.TestCase):
         self.assertIn('https://synbiohub.org/public/igem/BBa_B0034/1', identities)
         self.assertNotIn('https://synbiohub.org/public/igem/BBa_I13617/1', identities)
 
+    # https://github.com/SynBioDex/pySBOL2/issues/451
     @unittest.skipIf(password is None, "No SynBioHub password supplied")
     def test_gsoc_example_5(self):
         # Looking for: https://synbiohub.org/public/bsu/BO_28874/1
@@ -148,6 +154,7 @@ class TestSearchQuery(unittest.TestCase):
         self.assertIn('https://synbiohub.org/public/bsu/BO_28874/1', identities)
         self.assertNotIn('https://synbiohub.org/public/bsu/BO_26604/1', identities)
 
+    # https://github.com/SynBioDex/pySBOL2/issues/451
     @unittest.skipIf(password is None, "No SynBioHub password supplied")
     def test_gsoc_count_5(self):
         part_shop = sbol2.PartShop(GSOC_SBH_URL)

--- a/test/test_tutorial.py
+++ b/test/test_tutorial.py
@@ -119,6 +119,7 @@ class TestSbolTutorial(unittest.TestCase):
         my_device.compile()
         self.assertEqual(expected_sequence, my_device.sequence.elements)
 
+    @unittest.skip("SynBioHub no longer allows anonymous access")
     def test_tutorial(self):
         doc = self.init_tutorial()
         self.get_device_from_xml(doc)

--- a/test/test_tutorial.py
+++ b/test/test_tutorial.py
@@ -119,6 +119,7 @@ class TestSbolTutorial(unittest.TestCase):
         my_device.compile()
         self.assertEqual(expected_sequence, my_device.sequence.elements)
 
+    # https://github.com/SynBioDex/pySBOL2/issues/451
     @unittest.skip("SynBioHub no longer allows anonymous access")
     def test_tutorial(self):
         doc = self.init_tutorial()


### PR DESCRIPTION
This pull request repairs the failing builds (GitHub Actions) in two ways:

1. Constrain the version of packaging until we add a workaround for `NegativeInfinity` (see #450 )
2. Skip SynBioHub tests that we think now require authentication (see #451)

Additionally, update the minimum version of Python from 3.7 to 3.11 and update the list of Python versions included in the GitHub Actions builds.

Closes #449 
